### PR TITLE
chore: simplify hero headline to "KAAN USTA"

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -98,7 +98,7 @@ import { SITE } from '@lib/constants';
     <h1
       class="font-mono font-semibold tracking-widest text-5xl sm:text-7xl text-text-100 leading-tight"
     >
-      Y. KAAN <span class="text-accent-1">USTA</span>
+      KAAN <span class="text-accent-1">USTA</span>
     </h1>
 
     <p


### PR DESCRIPTION
Drop the "Y." prefix on the homepage hero. One-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)