### PR TITLE
fix(lite-youtube): full-width iframe on click

### DIFF
--- a/src/components/LiteYouTube.astro
+++ b/src/components/LiteYouTube.astro
@@ -116,6 +116,8 @@ const posterFallback = `https://i.ytimg.com/vi/${id}/hqdefault.jpg`;
             'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share';
           iframe.allowFullscreen = true;
           iframe.setAttribute('frameborder', '0');
+          // Inline styles — Astro scoped CSS won't reach dynamically created elements
+          iframe.style.cssText = 'position:absolute;inset:0;width:100%;height:100%;border:0;';
           this.replaceChildren(iframe);
         },
         { once: true }


### PR DESCRIPTION
## Summary
- YouTube iframe was rendering at its intrinsic size instead of filling the 16:9 container
- Root cause: Astro scoped CSS doesn't reach dynamically created elements (the iframe is injected via JS on click)
- Fix: apply `position:absolute;inset:0;width:100%;height:100%` inline at creation time

## Test plan
- [x] Open `/projects/orbs-of-the-power/`
- [x] Click YouTube poster → iframe fills full container width
- [x] Verified on localhost via Chrome MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)