### PR TITLE
feat(projects): open project details in modal overlay

### DIFF
--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -15,6 +15,7 @@ const platformVariant =
 
 <a
   href={`/projects/${project.id}`}
+  data-project-modal
   class="group block border border-border bg-bg-elev transition-all duration-200 hover:border-accent-1 hover:shadow-glow-cyan hover:-translate-y-0.5 overflow-hidden"
 >
   {

--- a/src/components/ProjectModal.astro
+++ b/src/components/ProjectModal.astro
@@ -1,0 +1,112 @@
+---
+/**
+ * ProjectModal — full-screen overlay for project details.
+ *
+ * Hidden by default. Client JS in BaseLayout opens it by fetching the
+ * project detail page, extracting `#project-detail`, and injecting the
+ * HTML here. Closes via X button, backdrop click, Escape, or browser back.
+ */
+---
+
+<div
+  id="project-modal"
+  class="fixed inset-0 z-50 hidden"
+  role="dialog"
+  aria-modal="true"
+  aria-label="Project details"
+>
+  {/* Backdrop */}
+  <div
+    id="project-modal-backdrop"
+    class="absolute inset-0 bg-black/70 backdrop-blur-sm cursor-pointer transition-opacity duration-300 opacity-0"
+  ></div>
+
+  {/* Scroll wrapper — covers the full overlay area; clicks outside the panel close the modal */}
+  <div id="project-modal-wrapper" class="relative z-10 flex items-start justify-center h-full overflow-y-auto overscroll-contain py-8 px-4 sm:px-6 cursor-pointer">
+    <div
+      id="project-modal-panel"
+      class="relative w-full max-w-4xl bg-bg-base border border-border shadow-2xl transition-all duration-300 origin-top scale-95 opacity-0 my-auto cursor-default"
+    >
+      {/* Close bar — sticky so it's always visible while scrolling */}
+      <div class="sticky top-0 z-20 flex justify-end p-3 bg-bg-base/90 backdrop-blur-sm border-b border-border">
+        <button
+          id="project-modal-close"
+          type="button"
+          aria-label="Close project"
+          class="flex items-center justify-center w-10 h-10 border border-border text-text-300 hover:text-accent-1 hover:border-accent-1 hover:shadow-glow-cyan transition-all duration-200 font-mono text-lg"
+        >
+          &times;
+        </button>
+      </div>
+
+      {/* Content — injected via JS */}
+      <div id="project-modal-content" class="p-6 sm:p-8">
+        {/* Loading state */}
+        <div id="project-modal-loader" class="flex flex-col items-center justify-center py-20 gap-4">
+          <div class="w-8 h-8 border-2 border-accent-1 border-t-transparent rounded-full animate-spin"></div>
+          <span class="font-mono text-xs uppercase tracking-widest text-text-300">Loading...</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style is:global>
+  /* Body scroll lock when modal is open */
+  html.modal-open {
+    overflow: hidden;
+  }
+
+  /* Modal visible state — toggled via JS */
+  #project-modal.is-open {
+    display: block;
+  }
+  #project-modal.is-open #project-modal-backdrop {
+    opacity: 1;
+  }
+  #project-modal.is-open #project-modal-panel {
+    scale: 1;
+    opacity: 1;
+  }
+
+  /* Remove the "← Back to Projects" link and page chrome when inside modal */
+  #project-modal-content a[href="/projects"] {
+    display: none;
+  }
+
+  /* Prose styles inside modal — reuse the existing prose-content styles */
+  #project-modal-content .prose-content h2 {
+    @apply font-mono text-text-100 text-xl mt-10 mb-4 uppercase tracking-widest;
+  }
+  #project-modal-content .prose-content h3 {
+    @apply font-mono text-text-100 text-lg mt-8 mb-3;
+  }
+  #project-modal-content .prose-content p {
+    @apply text-text-200;
+  }
+  #project-modal-content .prose-content ul {
+    @apply list-disc list-inside space-y-2 text-text-200 marker:text-accent-1;
+  }
+  #project-modal-content .prose-content ol {
+    @apply list-decimal list-inside space-y-2 text-text-200 marker:text-accent-1;
+  }
+  #project-modal-content .prose-content strong {
+    @apply text-text-100;
+  }
+  #project-modal-content .prose-content a {
+    @apply text-accent-1 hover:underline underline-offset-4;
+  }
+  #project-modal-content .prose-content code {
+    @apply bg-bg-elev px-1.5 py-0.5 font-mono text-sm text-accent-1 border border-border;
+  }
+  #project-modal-content .prose-content blockquote {
+    @apply border-l-2 border-accent-1 pl-4 italic text-text-300;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    #project-modal-backdrop,
+    #project-modal-panel {
+      transition: none !important;
+    }
+  }
+</style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,6 +5,7 @@ import Header from '@components/Header.astro';
 import Footer from '@components/Footer.astro';
 import CustomCursor from '@components/CustomCursor.astro';
 import SoundFx from '@components/SoundFx.astro';
+import ProjectModal from '@components/ProjectModal.astro';
 import { SITE } from '@lib/constants';
 
 interface Props {
@@ -69,6 +70,7 @@ const socialImage = new URL(image, SITE.url).href;
       <slot />
     </main>
     <Footer />
+    <ProjectModal />
 
     {/* Scroll-triggered fade-in for elements with data-fade-in attribute. */}
     <script>
@@ -99,6 +101,114 @@ const socialImage = new URL(image, SITE.url).href;
 
       setupFadeIn();
       document.addEventListener('astro:page-load', setupFadeIn);
+    </script>
+
+    {/* Project modal — intercepts card clicks, fetches detail page, shows overlay */}
+    <script is:inline>
+      // Project modal — must be is:inline so it runs immediately, before Astro's
+      // ClientRouter can register its own click handlers on <a> tags.
+      (function() {
+        var modal = document.getElementById('project-modal');
+        var wrapper = document.getElementById('project-modal-wrapper');
+        var closeBtn = document.getElementById('project-modal-close');
+        var contentEl = document.getElementById('project-modal-content');
+        if (!modal || !wrapper || !closeBtn || !contentEl) return;
+
+        var originalUrl = '';
+        var isOpen = false;
+
+        function openModal() {
+          originalUrl = location.href;
+          modal.classList.remove('hidden');
+          void modal.offsetHeight;
+          modal.classList.add('is-open');
+          document.documentElement.classList.add('modal-open');
+          isOpen = true;
+          closeBtn.focus();
+        }
+
+        function closeModal(updateUrl) {
+          if (!isOpen) return;
+          if (updateUrl === undefined) updateUrl = true;
+          modal.classList.remove('is-open');
+          document.documentElement.classList.remove('modal-open');
+          isOpen = false;
+
+          if (updateUrl && originalUrl) {
+            history.pushState(null, '', originalUrl);
+          }
+
+          setTimeout(function() {
+            modal.classList.add('hidden');
+            contentEl.innerHTML =
+              '<div class="flex flex-col items-center justify-center py-20 gap-4">' +
+              '<div class="w-8 h-8 border-2 border-accent-1 border-t-transparent rounded-full animate-spin"></div>' +
+              '<span class="font-mono text-xs uppercase tracking-widest text-text-300">Loading...</span>' +
+              '</div>';
+          }, 300);
+        }
+
+        function loadProject(href) {
+          openModal();
+          history.pushState({ projectModal: true }, '', href);
+
+          fetch(href)
+            .then(function(res) {
+              if (!res.ok) throw new Error('HTTP ' + res.status);
+              return res.text();
+            })
+            .then(function(html) {
+              var doc = new DOMParser().parseFromString(html, 'text/html');
+              var article = doc.getElementById('project-detail');
+              if (article) {
+                contentEl.innerHTML = article.innerHTML;
+                // Re-init LiteYouTube custom elements inside modal
+                contentEl.querySelectorAll('lite-youtube').forEach(function(el) {
+                  if (customElements.get('lite-youtube')) {
+                    var clone = el.cloneNode(true);
+                    el.replaceWith(clone);
+                  }
+                });
+              } else {
+                closeModal();
+                location.href = href;
+              }
+            })
+            .catch(function() {
+              closeModal();
+              location.href = href;
+            });
+        }
+
+        // Capture phase click — fires BEFORE Astro ClientRouter
+        document.addEventListener('click', function(e) {
+          var el = e.target;
+          while (el && el !== document) {
+            if (el.tagName === 'A' && el.hasAttribute('data-project-modal')) {
+              e.preventDefault();
+              e.stopImmediatePropagation();
+              loadProject(el.href);
+              return;
+            }
+            el = el.parentElement;
+          }
+        }, true);
+
+        // Close handlers
+        closeBtn.addEventListener('click', function() { closeModal(); });
+
+        wrapper.addEventListener('click', function(e) {
+          if (e.target === wrapper) closeModal();
+        });
+
+        document.addEventListener('keydown', function(e) {
+          if (e.key === 'Escape' && isOpen) closeModal();
+        });
+
+        window.addEventListener('popstate', function() {
+          if (isOpen) closeModal(false);
+        });
+      })();
     </script>
   </body>
 </html>

--- a/src/pages/projects/[...slug].astro
+++ b/src/pages/projects/[...slug].astro
@@ -37,7 +37,7 @@ const platformVariant =
 ---
 
 <BaseLayout title={title} description={description}>
-  <article class="max-w-3xl mx-auto px-6 py-16">
+  <article id="project-detail" class="max-w-3xl mx-auto px-6 py-16">
     <a
       href="/projects"
       class="inline-block font-mono text-xs uppercase tracking-widest text-text-300 hover:text-accent-1 mb-8"


### PR DESCRIPTION
## Summary
- Project cards now open as a modal overlay instead of full-page navigation
- Background page stays visible behind dark backdrop with blur
- Close via: X button, backdrop click, Escape key, or browser back
- URL updates via pushState (shareable links still work)
- Direct `/projects/[slug]` pages unchanged (SEO + fallback)
- Also includes LiteYouTube iframe sizing fix from previous commit

## Test plan
- [x] Click project card on homepage → modal opens with cover, video, details
- [x] X button closes modal
- [x] Backdrop click closes modal  
- [x] Escape key closes modal
- [x] Browser back closes modal
- [x] Direct URL `/projects/orbs-of-the-power` → normal page (no modal)
- [x] Build passes (11 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)