### PR TITLE
refactor(modal): top-right + FAB close buttons

### DIFF
--- a/src/components/ProjectModal.astro
+++ b/src/components/ProjectModal.astro
@@ -4,7 +4,8 @@
  *
  * Hidden by default. Client JS in BaseLayout opens it by fetching the
  * project detail page, extracting `#project-detail`, and injecting the
- * HTML here. Closes via X button, backdrop click, Escape, or browser back.
+ * HTML here. Closes via X button (top + FAB), backdrop click, Escape,
+ * or browser back.
  */
 ---
 
@@ -27,17 +28,15 @@
       id="project-modal-panel"
       class="relative w-full max-w-4xl bg-bg-base border border-border shadow-2xl transition-all duration-300 origin-top scale-95 opacity-0 my-auto cursor-default"
     >
-      {/* Close bar — sticky so it's always visible while scrolling */}
-      <div class="sticky top-0 z-20 flex justify-end p-3 bg-bg-base/90 backdrop-blur-sm border-b border-border">
-        <button
-          id="project-modal-close"
-          type="button"
-          aria-label="Close project"
-          class="flex items-center justify-center w-10 h-10 border border-border text-text-300 hover:text-accent-1 hover:border-accent-1 hover:shadow-glow-cyan transition-all duration-200 font-mono text-lg"
-        >
-          &times;
-        </button>
-      </div>
+      {/* Top-right close — absolute, scrolls away with content */}
+      <button
+        id="project-modal-close"
+        type="button"
+        aria-label="Close project"
+        class="absolute top-3 right-3 z-20 flex items-center justify-center w-8 h-8 border border-border bg-bg-base/80 text-text-300 hover:text-accent-1 hover:border-accent-1 hover:shadow-glow-cyan transition-all duration-200 font-mono text-sm"
+      >
+        &times;
+      </button>
 
       {/* Content — injected via JS */}
       <div id="project-modal-content" class="p-6 sm:p-8">
@@ -49,6 +48,16 @@
       </div>
     </div>
   </div>
+
+  {/* FAB close — fixed bottom-right, always visible while modal is open */}
+  <button
+    id="project-modal-fab"
+    type="button"
+    aria-label="Close project"
+    class="fixed bottom-6 right-6 z-[60] flex items-center justify-center w-12 h-12 border border-border bg-bg-base/80 backdrop-blur-sm text-text-300 hover:text-accent-1 hover:border-accent-1 hover:shadow-glow-cyan transition-all duration-200 font-mono text-xl shadow-lg"
+  >
+    &times;
+  </button>
 </div>
 
 <style is:global>
@@ -69,7 +78,7 @@
     opacity: 1;
   }
 
-  /* Remove the "← Back to Projects" link and page chrome when inside modal */
+  /* Remove the "← Back to Projects" link when inside modal */
   #project-modal-content a[href="/projects"] {
     display: none;
   }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -111,8 +111,9 @@ const socialImage = new URL(image, SITE.url).href;
         var modal = document.getElementById('project-modal');
         var wrapper = document.getElementById('project-modal-wrapper');
         var closeBtn = document.getElementById('project-modal-close');
+        var fabBtn = document.getElementById('project-modal-fab');
         var contentEl = document.getElementById('project-modal-content');
-        if (!modal || !wrapper || !closeBtn || !contentEl) return;
+        if (!modal || !wrapper || !closeBtn || !fabBtn || !contentEl) return;
 
         var originalUrl = '';
         var isOpen = false;
@@ -196,6 +197,7 @@ const socialImage = new URL(image, SITE.url).href;
 
         // Close handlers
         closeBtn.addEventListener('click', function() { closeModal(); });
+        fabBtn.addEventListener('click', function() { closeModal(); });
 
         wrapper.addEventListener('click', function(e) {
           if (e.target === wrapper) closeModal();


### PR DESCRIPTION
## Summary
- Removed sticky close bar (border + background looked bad when scrolling)
- Top-right: small (32px) absolute X button, scrolls away naturally
- Bottom-right: FAB-style (48px) fixed X button, always visible like a scroll-to-top button
- FAB has translucent background + backdrop blur + hover glow
- On mobile, FAB may slightly overlap content — acceptable trade-off for always-accessible close

## Test plan
- [x] Build passes
- [ ] Open modal → top-right X visible at start
- [ ] Scroll down → FAB always visible at bottom-right
- [ ] Both buttons close the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)