### PR TITLE
fix(modal): work across ViewTransitions navigations

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -105,33 +105,38 @@ const socialImage = new URL(image, SITE.url).href;
 
     {/* Project modal — intercepts card clicks, fetches detail page, shows overlay */}
     <script is:inline>
-      // Project modal — must be is:inline so it runs immediately, before Astro's
-      // ClientRouter can register its own click handlers on <a> tags.
+      // Project modal — is:inline so it runs before Astro ClientRouter.
+      // All element lookups are fresh (no cached refs) because ViewTransitions
+      // replaces the DOM on navigation, detaching old elements.
       (function() {
-        var modal = document.getElementById('project-modal');
-        var wrapper = document.getElementById('project-modal-wrapper');
-        var closeBtn = document.getElementById('project-modal-close');
-        var fabBtn = document.getElementById('project-modal-fab');
-        var contentEl = document.getElementById('project-modal-content');
-        if (!modal || !wrapper || !closeBtn || !fabBtn || !contentEl) return;
+        if (window.__projectModalInit) return; // guard against double-init
+        window.__projectModalInit = true;
 
         var originalUrl = '';
         var isOpen = false;
 
+        // Fresh DOM lookups — always get current elements after ViewTransitions swaps
+        function $(id) { return document.getElementById(id); }
+
         function openModal() {
+          var modal = $('project-modal');
+          var closeBtn = $('project-modal-close');
+          if (!modal) return;
           originalUrl = location.href;
           modal.classList.remove('hidden');
           void modal.offsetHeight;
           modal.classList.add('is-open');
           document.documentElement.classList.add('modal-open');
           isOpen = true;
-          closeBtn.focus();
+          if (closeBtn) closeBtn.focus();
         }
 
         function closeModal(updateUrl) {
           if (!isOpen) return;
           if (updateUrl === undefined) updateUrl = true;
-          modal.classList.remove('is-open');
+          var modal = $('project-modal');
+          var contentEl = $('project-modal-content');
+          if (modal) modal.classList.remove('is-open');
           document.documentElement.classList.remove('modal-open');
           isOpen = false;
 
@@ -140,13 +145,34 @@ const socialImage = new URL(image, SITE.url).href;
           }
 
           setTimeout(function() {
-            modal.classList.add('hidden');
-            contentEl.innerHTML =
+            var m = $('project-modal');
+            var c = $('project-modal-content');
+            if (m) m.classList.add('hidden');
+            if (c) c.innerHTML =
               '<div class="flex flex-col items-center justify-center py-20 gap-4">' +
               '<div class="w-8 h-8 border-2 border-accent-1 border-t-transparent rounded-full animate-spin"></div>' +
               '<span class="font-mono text-xs uppercase tracking-widest text-text-300">Loading...</span>' +
               '</div>';
           }, 300);
+        }
+
+        function initYouTubeEmbeds(container) {
+          container.querySelectorAll('.lite-yt').forEach(function(yt) {
+            var btn = yt.querySelector('button');
+            if (!btn) return;
+            btn.addEventListener('click', function() {
+              var vid = yt.getAttribute('data-id');
+              var ttl = yt.getAttribute('data-title') || 'YouTube video';
+              if (!vid) return;
+              var iframe = document.createElement('iframe');
+              iframe.src = 'https://www.youtube-nocookie.com/embed/' + encodeURIComponent(vid) + '?autoplay=1&rel=0';
+              iframe.title = ttl;
+              iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share';
+              iframe.allowFullscreen = true;
+              iframe.style.cssText = 'position:absolute;inset:0;width:100%;height:100%;border:0;';
+              yt.replaceChildren(iframe);
+            }, { once: true });
+          });
         }
 
         function loadProject(href) {
@@ -159,28 +185,12 @@ const socialImage = new URL(image, SITE.url).href;
               return res.text();
             })
             .then(function(html) {
+              var contentEl = $('project-modal-content');
               var doc = new DOMParser().parseFromString(html, 'text/html');
               var article = doc.getElementById('project-detail');
-              if (article) {
+              if (article && contentEl) {
                 contentEl.innerHTML = article.innerHTML;
-                // Init YouTube embeds — custom element may not be defined on this page,
-                // so we attach click handlers directly instead of relying on connectedCallback.
-                contentEl.querySelectorAll('.lite-yt').forEach(function(yt) {
-                  var btn = yt.querySelector('button');
-                  if (!btn) return;
-                  btn.addEventListener('click', function() {
-                    var vid = yt.getAttribute('data-id');
-                    var ttl = yt.getAttribute('data-title') || 'YouTube video';
-                    if (!vid) return;
-                    var iframe = document.createElement('iframe');
-                    iframe.src = 'https://www.youtube-nocookie.com/embed/' + encodeURIComponent(vid) + '?autoplay=1&rel=0';
-                    iframe.title = ttl;
-                    iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share';
-                    iframe.allowFullscreen = true;
-                    iframe.style.cssText = 'position:absolute;inset:0;width:100%;height:100%;border:0;';
-                    yt.replaceChildren(iframe);
-                  }, { once: true });
-                });
+                initYouTubeEmbeds(contentEl);
               } else {
                 closeModal();
                 location.href = href;
@@ -202,16 +212,26 @@ const socialImage = new URL(image, SITE.url).href;
               loadProject(el.href);
               return;
             }
+            // Close buttons (top-right X or FAB)
+            if (el.id === 'project-modal-close' || el.id === 'project-modal-fab') {
+              closeModal();
+              return;
+            }
+            // Wrapper click (outside panel)
+            if (el.id === 'project-modal-wrapper') {
+              closeModal();
+              return;
+            }
             el = el.parentElement;
           }
         }, true);
 
-        // Close handlers
-        closeBtn.addEventListener('click', function() { closeModal(); });
-        fabBtn.addEventListener('click', function() { closeModal(); });
-
-        wrapper.addEventListener('click', function(e) {
-          if (e.target === wrapper) closeModal();
+        // Stop panel clicks from reaching wrapper handler
+        document.addEventListener('click', function(e) {
+          var panel = $('project-modal-panel');
+          if (panel && isOpen && panel.contains(e.target) && e.target.id !== 'project-modal-close') {
+            e.stopPropagation();
+          }
         });
 
         document.addEventListener('keydown', function(e) {


### PR DESCRIPTION
## Summary
- Modal stopped working after ViewTransitions page swap (e.g. navigating to /projects then clicking cards)
- Root cause: cached element refs pointed to detached DOM after ClientRouter swapped `<body>`
- Fix: all functions use fresh `getElementById()` lookups; close handlers use event delegation

## Test plan
- [ ] Open modal from homepage → works
- [ ] Navigate to /projects → click card → modal opens
- [ ] Navigate back to homepage → click card → modal still opens
- [ ] Close via X, FAB, backdrop, Escape, back button — all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)