### PR TITLE
feat(orbs): add cover to gallery

### DIFF
--- a/src/content/projects/orbs-of-the-power.md
+++ b/src/content/projects/orbs-of-the-power.md
@@ -11,6 +11,7 @@ links:
   github: "https://github.com/KaanEkimoz/Orbs-of-The-Power"
 coverImage: "../../assets/projects/orbs-of-the-power/cover.png"
 gallery:
+  - "../../assets/projects/orbs-of-the-power/cover.png"
   - "../../assets/projects/orbs-of-the-power/gallery/01.png"
 youtubeId: "0KpRHhH52hQ"
 featured: true


### PR DESCRIPTION
## Summary
- Added cover.png as the first screenshot in the gallery section
- Same image used for both cover hero and gallery — will be replaced later

🤖 Generated with [Claude Code](https://claude.com/claude-code)