### PR TITLE
fix(header): hide FX toggle on mobile, harden against storage failures

### DIFF
--- a/src/components/FxToggle.astro
+++ b/src/components/FxToggle.astro
@@ -103,15 +103,30 @@
     return `fx-${fx}`;
   }
 
+  // In-memory fallback for when localStorage is unavailable
+  // (Brave "Forget on site", Safari ITP, incognito quota, etc.)
+  const memoryState: Partial<Record<FxKey, 'on' | 'off'>> = {};
+
   function getState(fx: FxKey): boolean {
-    const stored = localStorage.getItem(storageKey(fx));
+    let stored: string | null = null;
+    try {
+      stored = localStorage.getItem(storageKey(fx));
+    } catch {
+      stored = memoryState[fx] ?? null;
+    }
     if (stored === 'on') return true;
     if (stored === 'off') return false;
     return DEFAULTS[fx] === 'on';
   }
 
   function setState(fx: FxKey, on: boolean) {
-    localStorage.setItem(storageKey(fx), on ? 'on' : 'off');
+    const value = on ? 'on' : 'off';
+    memoryState[fx] = value;
+    try {
+      localStorage.setItem(storageKey(fx), value);
+    } catch {
+      // Storage blocked — keep going with memoryState so the UI still toggles.
+    }
     document.dispatchEvent(
       new CustomEvent(`fx:${fx}-changed`, { detail: { on } })
     );

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -36,7 +36,7 @@ const isActive = (href: string) =>
           </a>
         ))
       }
-      <div class="ml-0 sm:ml-2 pl-3 sm:pl-4 border-l border-border">
+      <div class="hidden sm:block ml-2 pl-4 border-l border-border">
         <FxToggle />
       </div>
     </nav>


### PR DESCRIPTION
## Summary
- **Mobile**: hide the FX toggle entirely below sm — cursor toggle is already a no-op on coarse-pointer devices, and sound is rarely useful on phones
- **Brave / Safari fix**: wrap localStorage calls in try/catch with an in-memory fallback so clicks always toggle the UI, even when Shields or ITP blocks storage

## Why
- Kaan reported the two header buttons (cursor / sound) do nothing in Brave. A friend's Chrome works. The most likely cause is Brave blocking localStorage in strict mode — `getItem` / `setItem` throws, which crashes the click handler silently.
- The fallback keeps state in memory for the tab, so UI + downstream custom events still fire.

## Test plan
- [x] `npm run build` passes
- [ ] Deployed site: click both toggles in Brave — should respond visually + trigger cursor/sound
- [ ] On phone: buttons no longer visible in header