### PR TITLE
fix(contact): wrap social links and shrink email on mobile

### DIFF
--- a/src/components/SocialLinks.astro
+++ b/src/components/SocialLinks.astro
@@ -22,7 +22,7 @@ const {
 const sizeCls = size === 'sm' ? 'text-[10px]' : 'text-xs';
 ---
 
-<ul class="flex items-center gap-4">
+<ul class="flex flex-wrap items-center gap-x-4 gap-y-2">
   {
     channels.map((key) => {
       const item = links[key];

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -117,7 +117,7 @@ const latestPosts = allPosts
     <div class="border border-border bg-bg-elev p-8 sm:p-12">
       <a
         href={`mailto:${SOCIAL.email}`}
-        class="block font-mono text-2xl sm:text-3xl text-text-100 hover:text-accent-1 transition-colors break-all"
+        class="block font-mono text-base sm:text-2xl md:text-3xl text-text-100 hover:text-accent-1 transition-colors break-all"
       >
         {SOCIAL.email}
       </a>


### PR DESCRIPTION
## Summary
- Social links wrap to a second line on narrow viewports (YouTube + Itch.io no longer overflow the card)
- Email starts at text-base on mobile so kaanekimoz@gmail.com fits on a single line at 320px

## Test plan
- [x] Verified locally on phone (http://172.2.3.165:4321)
- [ ] Deployed site on a 320px viewport renders both rows cleanly