### PR TITLE
fix(a11y): lift text-300 for WCAG AA contrast (Faz 7.3)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -25,7 +25,7 @@
   /* Text hierarchy */
   --text-100: #f0f0f5;
   --text-200: #b8b8c8;
-  --text-300: #6c6c80;
+  --text-300: #a8a8c0;
 
   /* Border */
   --border: #2a2a3a;

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -21,7 +21,7 @@ export default {
         text: {
           100: '#f0f0f5', // headings
           200: '#b8b8c8', // body
-          300: '#6c6c80', // meta, muted
+          300: '#a8a8c0', // meta, muted — WCAG AA contrast on bg-base (~7:1)
         },
         border: {
           DEFAULT: '#2a2a3a',


### PR DESCRIPTION
## Summary
Raise \`text-300\` from \`#6c6c80\` to \`#a8a8c0\` in both \`global.css\` (CSS variable) and \`tailwind.config.mjs\` (theme color the utility class compiles against). Ratio goes from 3.83:1 → ~7:1 on bg-base, clearing WCAG AA + AAA.

## What changed visually
Small muted text gets easier to read: nav PROJECTS / BLOG (inactive), hero \`/// PORTFOLIO · BLOG\` tag, \`SCROLL\` pill, footer copyright / build credit / location line.

Hero headlines, body text, active nav, hovers — all unchanged.

## Lighthouse (localhost preview)
Before: perf 99 / a11y 96 / bp 100 / seo 100
After:  perf 100 / a11y 100 / bp 100 / seo 100

Real-site scores will land a couple points below localhost (CDN vs local file serving). The a11y delta is the substantive one.