### PR TITLE
chore(branding): drop "Y." initial from author name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kaanusta.dev
 
-Personal portfolio and blog for **Y. Kaan Usta** — game developer, Unity / C#, mobile-focused.
+Personal portfolio and blog for **Kaan Usta** — game developer, Unity / C#, mobile-focused.
 
 **Live:** [kaanusta.dev](https://kaanusta.dev)
 
@@ -82,4 +82,4 @@ Pushing to `main` triggers `.github/workflows/deploy.yml`, which builds with Ast
 
 ## License
 
-© Y. Kaan Usta. All rights reserved. The source is public so you can read and learn from it, but code, design, images, and written content may not be reused without permission.
+© Kaan Usta. All rights reserved. The source is public so you can read and learn from it, but code, design, images, and written content may not be reused without permission.

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -52,7 +52,7 @@ const socialImage = new URL(image, SITE.url).href;
     <meta property="og:image:type" content="image/jpeg" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="kaanusta.dev — Y. Kaan Usta, game developer" />
+    <meta property="og:image:alt" content="kaanusta.dev — Kaan Usta, game developer" />
     <meta property="og:locale" content={SITE.locale} />
     <meta property="og:site_name" content={SITE.name} />
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -5,11 +5,11 @@
 
 export const SITE = {
   name: 'kaanusta.dev',
-  title: 'Y. Kaan Usta — Game Developer',
+  title: 'Kaan Usta — Game Developer',
   description:
     'Building mobile games since 2020. Specialized in Unity, focused on lightweight, addictive experiences.',
   url: 'https://kaanusta.dev',
-  author: 'Y. Kaan Usta',
+  author: 'Kaan Usta',
   locale: 'en-US',
 } as const;
 

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -9,7 +9,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
 );
 ---
 
-<BaseLayout title="Blog" description="Devlogs, post-mortems, and notes on game development from Y. Kaan Usta.">
+<BaseLayout title="Blog" description="Devlogs, post-mortems, and notes on game development from Kaan Usta.">
   <div class="max-w-3xl mx-auto px-6 py-16">
     <header class="mb-12">
       <SectionHeading title="Blog" as="h1" />

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -9,7 +9,7 @@ const projects = (await getCollection('projects')).sort(
 );
 ---
 
-<BaseLayout title="Projects" description="Games and prototypes by Y. Kaan Usta — mobile, PC, and VR.">
+<BaseLayout title="Projects" description="Games and prototypes by Kaan Usta — mobile, PC, and VR.">
   <div class="max-w-6xl mx-auto px-6 py-16">
     <header class="mb-12">
       <SectionHeading title="Projects" as="h1" />


### PR DESCRIPTION
## Summary
Simplify the wordmark to \`Kaan Usta\` everywhere. Matches the OG image (KAAN USTA) and day-to-day usage.

Touches:
- \`src/lib/constants.ts\` — SITE.title, SITE.author (propagates to header logo, tab title, footer, OG tags, canonical metadata)
- \`src/layouts/BaseLayout.astro\` — og:image:alt
- \`src/pages/projects/index.astro\` — page description
- \`src/pages/blog/index.astro\` — page description
- \`README.md\` — intro + license line