### PR TITLE
fix(hero): TIME IS UP heading + SoundFx under Brave Shields

### DIFF
--- a/src/components/HeroCanvas.astro
+++ b/src/components/HeroCanvas.astro
@@ -45,7 +45,7 @@
     <div
       class="border border-border bg-bg-base/85 backdrop-blur-sm px-5 py-3 flex flex-col items-center gap-2 font-mono"
     >
-      <div class="text-xs uppercase tracking-widest text-accent-2">GAME OVER</div>
+      <div class="text-xs uppercase tracking-widest text-accent-2">TIME IS UP</div>
       <div class="flex items-center gap-3">
         <span class="text-xs uppercase tracking-widest text-text-300">SCORE</span>
         <span class="hero-final-value text-lg text-accent-1">0</span>

--- a/src/components/SoundFx.astro
+++ b/src/components/SoundFx.astro
@@ -16,7 +16,16 @@
 <script>
   const STORAGE_KEY = 'fx-sound';
 
-  let enabled = localStorage.getItem(STORAGE_KEY) === 'on';
+  // Brave's Shields / Safari's ITP can throw on localStorage access; without
+  // a guard here the whole SoundFx module would crash at load time and never
+  // wire up the fx:sound-changed / fx:hit / fx:gameover listeners, so the
+  // toggle would visually flip but produce no audio.
+  let enabled = false;
+  try {
+    enabled = localStorage.getItem(STORAGE_KEY) === 'on';
+  } catch {
+    /* storage blocked — start disabled, the toggle event will flip this */
+  }
   let ctx: AudioContext | null = null;
   let unlocked = false;
 


### PR DESCRIPTION
## Summary
- Rename the round-end overlay heading: **GAME OVER → TIME IS UP**. Fits a 20-second round better.
- **Brave sound toggle fix**: wrap the initial \`localStorage.getItem\` in SoundFx.astro. Brave's Shields can throw on storage access, which was crashing the SoundFx module at load time — the FX toggle flipped visually but no event listeners were attached, so audio never played. Chrome was fine because it doesn't throw.

## Test plan
- [x] Build passes
- [ ] Brave: enable sound toggle → hear click feedback → hear hit tones in hero game → hear descending jingle at TIME IS UP
- [ ] Chrome: unchanged, still works