### PR TITLE
fix(blog): hero image left, text right

### DIFF
--- a/src/components/BlogCard.astro
+++ b/src/components/BlogCard.astro
@@ -18,37 +18,39 @@ const dateStr = pubDate.toLocaleDateString('en-US', {
 
 <a
   href={`/blog/${post.id}`}
-  class="group block border-l-2 border-border pl-4 py-2 transition-all duration-200 hover:border-accent-1"
+  class="group flex gap-4 items-start border-l-2 border-border pl-4 py-2 transition-all duration-200 hover:border-accent-1"
 >
   {
     heroImage && (
-      <div class="mb-3 overflow-hidden border border-border">
+      <div class="shrink-0 w-32 sm:w-40 overflow-hidden border border-border">
         <Image
           src={heroImage}
           alt=""
-          width={640}
-          height={360}
+          width={320}
+          height={180}
           loading="lazy"
           class="w-full aspect-[16/9] object-cover transition-transform duration-300 group-hover:scale-[1.02]"
         />
       </div>
     )
   }
-  <div class="font-mono text-xs uppercase tracking-widest text-accent-1 mb-1">
-    {dateStr}
-  </div>
-  <h3 class="font-mono font-semibold text-text-100 text-base group-hover:text-accent-1 transition-colors">
-    {title}
-  </h3>
-  <p class="text-text-200 text-sm mt-1 line-clamp-2">{description}</p>
-  {
-    tags.length > 0 && (
-      <div class="mt-2 font-mono text-[10px] uppercase tracking-widest text-text-300">
-        {tags.join(' · ')}
-      </div>
-    )
-  }
-  <div class="mt-2 font-mono text-xs uppercase tracking-widest text-text-300 group-hover:text-accent-1 transition-colors">
-    Read →
+  <div class="flex-1 min-w-0">
+    <div class="font-mono text-xs uppercase tracking-widest text-accent-1 mb-1">
+      {dateStr}
+    </div>
+    <h3 class="font-mono font-semibold text-text-100 text-base group-hover:text-accent-1 transition-colors">
+      {title}
+    </h3>
+    <p class="text-text-200 text-sm mt-1 line-clamp-2">{description}</p>
+    {
+      tags.length > 0 && (
+        <div class="mt-2 font-mono text-[10px] uppercase tracking-widest text-text-300">
+          {tags.join(' · ')}
+        </div>
+      )
+    }
+    <div class="mt-2 font-mono text-xs uppercase tracking-widest text-text-300 group-hover:text-accent-1 transition-colors">
+      Read →
+    </div>
   </div>
 </a>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -33,50 +33,51 @@ const dateStr = pubDate.toLocaleDateString('en-US', {
       ← Back to Blog
     </a>
 
-    {
-      heroImage && (
-        <div class="mb-8 overflow-hidden border border-border">
-          <Image
-            src={heroImage}
-            alt=""
-            width={1280}
-            height={720}
-            loading="eager"
-            class="w-full aspect-[16/9] object-cover"
-          />
-        </div>
-      )
-    }
-
-    <header class="mb-10 border-b border-border pb-8">
-      <div class="font-mono text-xs uppercase tracking-widest text-accent-1 mb-3">
-        {dateStr}
-        {updatedDate && (
-          <span class="text-text-300 ml-2">
-            · updated{' '}
-            {updatedDate.toLocaleDateString('en-US', {
-              year: 'numeric',
-              month: 'short',
-              day: 'numeric',
-            })}
-          </span>
-        )}
-      </div>
-      <h1
-        class="font-mono font-semibold text-4xl sm:text-5xl text-text-100 tracking-wide"
-      >
-        {title}
-      </h1>
-      <p class="mt-4 text-text-200 text-lg leading-relaxed">{description}</p>
+    <header class="mb-10 border-b border-border pb-8 flex flex-col sm:flex-row gap-6 items-start">
       {
-        tags.length > 0 && (
-          <div class="mt-4 flex flex-wrap gap-2">
-            {tags.map((t) => (
-              <Tag variant="muted">{t}</Tag>
-            ))}
+        heroImage && (
+          <div class="shrink-0 w-full sm:w-56 overflow-hidden border border-border">
+            <Image
+              src={heroImage}
+              alt=""
+              width={448}
+              height={252}
+              loading="eager"
+              class="w-full aspect-[16/9] object-cover"
+            />
           </div>
         )
       }
+      <div class="flex-1 min-w-0">
+        <div class="font-mono text-xs uppercase tracking-widest text-accent-1 mb-3">
+          {dateStr}
+          {updatedDate && (
+            <span class="text-text-300 ml-2">
+              · updated{' '}
+              {updatedDate.toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+              })}
+            </span>
+          )}
+        </div>
+        <h1
+          class="font-mono font-semibold text-3xl sm:text-4xl text-text-100 tracking-wide"
+        >
+          {title}
+        </h1>
+        <p class="mt-3 text-text-200 text-base leading-relaxed">{description}</p>
+        {
+          tags.length > 0 && (
+            <div class="mt-4 flex flex-wrap gap-2">
+              {tags.map((t) => (
+                <Tag variant="muted">{t}</Tag>
+              ))}
+            </div>
+          )
+        }
+      </div>
     </header>
 
     <div class="prose-content space-y-4 text-text-200 leading-relaxed">


### PR DESCRIPTION
Old: full-bleed banner above the card/post — cover image dwarfed the text. Now: horizontal flex row, ~160px thumb on BlogCard, ~224px on post header. Stacks to column under sm. Detail title also dropped one type notch so the right column reads like a card.