### PR TITLE
feat(theme): dark/light toggle

### DIFF
--- a/src/components/CustomCursor.astro
+++ b/src/components/CustomCursor.astro
@@ -56,7 +56,7 @@
     width: 6px;
     height: 6px;
     margin: -3px 0 0 -3px;
-    background: var(--accent-1);
+    background: rgb(var(--accent-1));
     border-radius: 50%;
   }
 
@@ -64,7 +64,7 @@
     width: 32px;
     height: 32px;
     margin: -16px 0 0 -16px;
-    border: 1px solid var(--accent-1);
+    border: 1px solid rgb(var(--accent-1));
     border-radius: 50%;
     transition: width 0.18s, height 0.18s, margin 0.18s, border-color 0.18s,
       background 0.18s, opacity 0.2s;
@@ -74,7 +74,7 @@
     width: 48px;
     height: 48px;
     margin: -24px 0 0 -24px;
-    border-color: var(--accent-2);
+    border-color: rgb(var(--accent-2));
     background: rgba(255, 77, 255, 0.08);
   }
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,6 +1,7 @@
 ---
 import { NAV, SITE } from '@lib/constants';
 import FxToggle from '@components/FxToggle.astro';
+import ThemeToggle from '@components/ThemeToggle.astro';
 
 const currentPath = Astro.url.pathname;
 const isActive = (href: string) =>
@@ -36,8 +37,11 @@ const isActive = (href: string) =>
           </a>
         ))
       }
-      <div class="hidden sm:block ml-2 pl-4 border-l border-border">
-        <FxToggle />
+      <div class="ml-2 pl-3 sm:pl-4 border-l border-border flex items-center gap-2">
+        <ThemeToggle />
+        <div class="hidden sm:block">
+          <FxToggle />
+        </div>
       </div>
     </nav>
   </div>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -12,12 +12,12 @@ import { SITE } from '@lib/constants';
   <div class="absolute inset-0 -z-30 pointer-events-none">
     <div
       class="absolute -top-32 -left-32 w-[600px] h-[600px] rounded-full blur-3xl opacity-30"
-      style="background: radial-gradient(circle, var(--accent-1) 0%, transparent 70%);"
+      style="background: radial-gradient(circle, rgb(var(--accent-1)) 0%, transparent 70%);"
     >
     </div>
     <div
       class="absolute -bottom-40 -right-32 w-[700px] h-[700px] rounded-full blur-3xl opacity-25"
-      style="background: radial-gradient(circle, var(--accent-2) 0%, transparent 70%);"
+      style="background: radial-gradient(circle, rgb(var(--accent-2)) 0%, transparent 70%);"
     >
     </div>
   </div>

--- a/src/components/HeroCanvas.astro
+++ b/src/components/HeroCanvas.astro
@@ -72,8 +72,8 @@
   }
 
   @keyframes hero-best-flash {
-    0%, 100% { color: var(--accent-1); }
-    50% { color: var(--accent-2); }
+    0%, 100% { color: rgb(var(--accent-1)); }
+    50% { color: rgb(var(--accent-2)); }
   }
   .hero-score.best-flash .hero-score-value {
     animation: hero-best-flash 500ms ease-in-out;

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,0 +1,155 @@
+---
+/**
+ * ThemeToggle
+ *
+ * Single header button that flips the site between dark (brand default)
+ * and light themes. Stores the choice in localStorage under 'fx-theme'.
+ * The initial value is set by an inline pre-paint script in BaseLayout
+ * to avoid a wrong-theme flash on load — this component only handles
+ * the click flip after hydration.
+ *
+ * Icon convention: the icon shown is the theme you would *switch to*.
+ *   - In dark mode → show sun  (click → light)
+ *   - In light mode → show moon (click → dark)
+ */
+---
+
+<button
+  type="button"
+  class="theme-btn"
+  aria-pressed="false"
+  aria-label="Toggle theme"
+  title="Theme"
+>
+  {/* Sun — visible when current theme is dark */}
+  <svg
+    class="icon-sun"
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    aria-hidden="true"
+  >
+    <circle cx="12" cy="12" r="4" />
+    <line x1="12" y1="2" x2="12" y2="5" />
+    <line x1="12" y1="19" x2="12" y2="22" />
+    <line x1="2" y1="12" x2="5" y2="12" />
+    <line x1="19" y1="12" x2="22" y2="12" />
+    <line x1="4.5" y1="4.5" x2="6.5" y2="6.5" />
+    <line x1="17.5" y1="17.5" x2="19.5" y2="19.5" />
+    <line x1="4.5" y1="19.5" x2="6.5" y2="17.5" />
+    <line x1="17.5" y1="6.5" x2="19.5" y2="4.5" />
+  </svg>
+
+  {/* Moon — visible when current theme is light */}
+  <svg
+    class="icon-moon"
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 A7 7 0 0 0 21 12.79z" />
+  </svg>
+</button>
+
+<style>
+  .theme-btn {
+    @apply inline-flex items-center justify-center w-7 h-7 border border-border text-text-300 transition-colors;
+  }
+  .theme-btn:hover {
+    @apply text-text-100;
+  }
+  .theme-btn[aria-pressed='true'] {
+    @apply text-accent-1 border-accent-1;
+  }
+
+  /* aria-pressed="false" = dark theme (default) → show sun, hide moon */
+  .theme-btn .icon-moon {
+    display: none;
+  }
+  .theme-btn[aria-pressed='true'] .icon-sun {
+    display: none;
+  }
+  .theme-btn[aria-pressed='true'] .icon-moon {
+    display: inline;
+  }
+</style>
+
+<script>
+  type Theme = 'dark' | 'light';
+  const STORAGE_KEY = 'fx-theme';
+  const THEME_COLOR: Record<Theme, string> = {
+    dark: '#0a0a14',
+    light: '#f5f4ef',
+  };
+
+  let memoryState: Theme | null = null;
+
+  function readStored(): Theme | null {
+    try {
+      const v = localStorage.getItem(STORAGE_KEY);
+      if (v === 'light' || v === 'dark') return v;
+    } catch {
+      /* storage blocked */
+    }
+    return null;
+  }
+
+  function getCurrent(): Theme {
+    // Trust the DOM first — the pre-paint script in BaseLayout already
+    // resolved the initial theme from storage / system preference.
+    const dom = document.documentElement.dataset.theme;
+    if (dom === 'light' || dom === 'dark') return dom;
+    return memoryState ?? readStored() ?? 'dark';
+  }
+
+  function applyTheme(theme: Theme) {
+    document.documentElement.dataset.theme = theme;
+    const meta = document.querySelector('meta[name="theme-color"]');
+    if (meta) meta.setAttribute('content', THEME_COLOR[theme]);
+  }
+
+  function setTheme(theme: Theme) {
+    memoryState = theme;
+    try {
+      localStorage.setItem(STORAGE_KEY, theme);
+    } catch {
+      /* storage blocked — memoryState still keeps us consistent for the session */
+    }
+    applyTheme(theme);
+  }
+
+  function syncButton(btn: HTMLButtonElement) {
+    btn.setAttribute('aria-pressed', getCurrent() === 'light' ? 'true' : 'false');
+  }
+
+  type Guarded = HTMLButtonElement & { __themeInited?: boolean };
+
+  function init() {
+    const buttons = document.querySelectorAll<HTMLButtonElement>('.theme-btn');
+    buttons.forEach((btn) => {
+      if ((btn as Guarded).__themeInited) {
+        syncButton(btn);
+        return;
+      }
+      (btn as Guarded).__themeInited = true;
+      syncButton(btn);
+      btn.addEventListener('click', () => {
+        setTheme(getCurrent() === 'light' ? 'dark' : 'light');
+        syncButton(btn);
+      });
+    });
+  }
+
+  init();
+  document.addEventListener('astro:page-load', init);
+</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -33,6 +33,31 @@ const socialImage = new URL(image, SITE.url).href;
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="generator" content={Astro.generator} />
+
+    {/* Pre-paint theme setter — must run before any styled content lays
+        out, otherwise the page flashes the wrong theme. Reads the user's
+        last choice from localStorage (key 'fx-theme'), falls back to the
+        system preference, and writes data-theme + theme-color before
+        first paint. */}
+    <script is:inline>
+      (function () {
+        try {
+          var stored = null;
+          try { stored = localStorage.getItem('fx-theme'); } catch (e) {}
+          var theme =
+            stored === 'light' || stored === 'dark'
+              ? stored
+              : (window.matchMedia &&
+                  window.matchMedia('(prefers-color-scheme: light)').matches
+                  ? 'light'
+                  : 'dark');
+          document.documentElement.dataset.theme = theme;
+          var meta = document.querySelector('meta[name="theme-color"]');
+          var color = theme === 'light' ? '#f5f4ef' : '#0a0a14';
+          if (meta) meta.setAttribute('content', color);
+        } catch (e) {}
+      })();
+    </script>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="canonical" href={canonicalUrl} />
     <link rel="sitemap" href="/sitemap-index.xml" />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,26 +9,45 @@
 @tailwind components;
 @tailwind utilities;
 
-/* CSS variables — single source of truth for the design system.
-   Tailwind theme reads these via tailwind.config.mjs. */
+/* Design tokens — space-separated RGB triplets so Tailwind's
+   `rgb(var(--xxx) / <alpha-value>)` syntax can splice in opacity
+   modifiers (e.g. `bg-bg-base/80`).
+   The :root block holds the DARK theme (the brand default).
+   The light theme is layered on top via the [data-theme="light"] selector. */
 :root {
   /* Background layers */
-  --bg-base: #0a0a14;
-  --bg-elev: #14141f;
-  --bg-elev-2: #1f1f2e;
+  --bg-base: 10 10 20;
+  --bg-elev: 20 20 31;
+  --bg-elev-2: 31 31 46;
 
-  /* Accent (cool palette) */
-  --accent-1: #00d9ff; /* cyan */
-  --accent-2: #ff4dff; /* magenta */
-  --accent-3: #ffd60a; /* amber */
+  /* Accent (cool palette) — same across themes; they're the brand. */
+  --accent-1: 0 217 255;    /* cyan */
+  --accent-2: 255 77 255;   /* magenta */
+  --accent-3: 255 214 10;   /* amber */
 
   /* Text hierarchy */
-  --text-100: #f0f0f5;
-  --text-200: #b8b8c8;
-  --text-300: #a8a8c0;
+  --text-100: 240 240 245;
+  --text-200: 184 184 200;
+  --text-300: 168 168 192;
 
   /* Border */
-  --border: #2a2a3a;
+  --border: 42 42 58;
+
+  color-scheme: dark;
+}
+
+html[data-theme='light'] {
+  --bg-base: 245 244 239;     /* warm off-white */
+  --bg-elev: 235 234 227;
+  --bg-elev-2: 223 223 214;
+
+  --text-100: 26 26 34;       /* near-black */
+  --text-200: 58 58 74;
+  --text-300: 108 108 128;    /* WCAG AA on bg-base */
+
+  --border: 207 207 196;
+
+  color-scheme: light;
 }
 
 @layer base {
@@ -50,8 +69,8 @@
   }
 
   ::selection {
-    background-color: var(--accent-1);
-    color: var(--bg-base);
+    background-color: rgb(var(--accent-1));
+    color: rgb(var(--bg-base));
   }
 
   /* Subtle scrollbar */
@@ -60,14 +79,14 @@
     height: 10px;
   }
   ::-webkit-scrollbar-track {
-    background: var(--bg-base);
+    background: rgb(var(--bg-base));
   }
   ::-webkit-scrollbar-thumb {
-    background: var(--bg-elev-2);
+    background: rgb(var(--bg-elev-2));
     border-radius: 0;
   }
   ::-webkit-scrollbar-thumb:hover {
-    background: var(--accent-1);
+    background: rgb(var(--accent-1));
   }
 }
 
@@ -78,8 +97,8 @@
     position: relative;
     width: 100%;
     aspect-ratio: 16 / 9;
-    background: var(--bg-elev);
-    border: 1px solid var(--border);
+    background: rgb(var(--bg-elev));
+    border: 1px solid rgb(var(--border));
     overflow: hidden;
   }
   .lite-yt-btn {

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -3,27 +3,28 @@ export default {
   content: ['./src/**/*.{astro,html,js,jsx,md,mdx,ts,tsx}'],
   theme: {
     extend: {
+      // Themed colors reference CSS variables defined in src/styles/global.css.
+      // The `<alpha-value>` placeholder lets Tailwind's opacity modifiers
+      // (e.g. bg-bg-base/80) splice the alpha in correctly. Light theme is
+      // applied by setting `data-theme="light"` on <html>.
       colors: {
-        // Background layers
         bg: {
-          base: '#0a0a14',
-          elev: '#14141f',
-          'elev-2': '#1f1f2e',
+          base: 'rgb(var(--bg-base) / <alpha-value>)',
+          elev: 'rgb(var(--bg-elev) / <alpha-value>)',
+          'elev-2': 'rgb(var(--bg-elev-2) / <alpha-value>)',
         },
-        // Accent colors (cool palette: cyan + magenta + amber)
         accent: {
-          1: '#00d9ff', // cyan — primary CTA, link, glow
-          2: '#ff4dff', // magenta — hover, secondary highlight
-          3: '#ffd60a', // amber — XP/level/reward emphasis
+          1: 'rgb(var(--accent-1) / <alpha-value>)', // cyan
+          2: 'rgb(var(--accent-2) / <alpha-value>)', // magenta
+          3: 'rgb(var(--accent-3) / <alpha-value>)', // amber
         },
-        // Text hierarchy
         text: {
-          100: '#f0f0f5', // headings
-          200: '#b8b8c8', // body
-          300: '#a8a8c0', // meta, muted — WCAG AA contrast on bg-base (~7:1)
+          100: 'rgb(var(--text-100) / <alpha-value>)', // headings
+          200: 'rgb(var(--text-200) / <alpha-value>)', // body
+          300: 'rgb(var(--text-300) / <alpha-value>)', // meta, muted
         },
         border: {
-          DEFAULT: '#2a2a3a',
+          DEFAULT: 'rgb(var(--border) / <alpha-value>)',
         },
       },
       fontFamily: {


### PR DESCRIPTION
Real light theme + header toggle button. Tokens become CSS variables (RGB triplets) so Tailwind opacity modifiers still work; pre-paint inline script in BaseLayout sets theme from localStorage / prefers-color-scheme before first paint to avoid FOUC; ThemeToggle handles the click flip with Brave-safe storage fallback and per-button __themeInited guard.