### PR TITLE
fix(theme): re-apply data-theme on astro:after-swap

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -38,24 +38,30 @@ const socialImage = new URL(image, SITE.url).href;
         out, otherwise the page flashes the wrong theme. Reads the user's
         last choice from localStorage (key 'fx-theme'), falls back to the
         system preference, and writes data-theme + theme-color before
-        first paint. */}
+        first paint. Also re-runs on astro:after-swap so the choice
+        survives ClientRouter view-transition navigations (the swap
+        otherwise resets <html> attributes back to the source markup). */}
     <script is:inline>
       (function () {
-        try {
-          var stored = null;
-          try { stored = localStorage.getItem('fx-theme'); } catch (e) {}
-          var theme =
-            stored === 'light' || stored === 'dark'
-              ? stored
-              : (window.matchMedia &&
-                  window.matchMedia('(prefers-color-scheme: light)').matches
-                  ? 'light'
-                  : 'dark');
-          document.documentElement.dataset.theme = theme;
-          var meta = document.querySelector('meta[name="theme-color"]');
-          var color = theme === 'light' ? '#f5f4ef' : '#0a0a14';
-          if (meta) meta.setAttribute('content', color);
-        } catch (e) {}
+        function apply() {
+          try {
+            var stored = null;
+            try { stored = localStorage.getItem('fx-theme'); } catch (e) {}
+            var theme =
+              stored === 'light' || stored === 'dark'
+                ? stored
+                : (window.matchMedia &&
+                    window.matchMedia('(prefers-color-scheme: light)').matches
+                    ? 'light'
+                    : 'dark');
+            document.documentElement.dataset.theme = theme;
+            var meta = document.querySelector('meta[name="theme-color"]');
+            var color = theme === 'light' ? '#f5f4ef' : '#0a0a14';
+            if (meta) meta.setAttribute('content', color);
+          } catch (e) {}
+        }
+        apply();
+        document.addEventListener('astro:after-swap', apply);
       })();
     </script>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />


### PR DESCRIPTION
## Summary
- Theme choice (light/dark) was reverting to dark on every internal navigation because Astro's `ClientRouter` view-transition swap resets `<html>` attributes back to the source markup, wiping the `data-theme` the pre-paint script had set.
- Wrap the theme resolver in an `apply()` function and re-run it on `astro:after-swap` so the stored choice survives view transitions.
- Initial full-page load behavior is unchanged.

## Test plan
- [x] Open `/`, click theme toggle → goes light, `localStorage.fx-theme === 'light'`, `<html data-theme="light">`
- [x] Click header **Blog** link (ClientRouter nav) → stays light on `/blog`
- [x] Navigate back to home → stays light
- [x] Verified in Chrome at localhost:4321

🤖 Generated with [Claude Code](https://claude.com/claude-code)