### PR TITLE
content(i18n): rewrite TR content natively + polish EN

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -8,11 +8,6 @@ interface Props {
 
 const { lang = DEFAULT_LOCALE } = Astro.props;
 const year = new Date().getFullYear();
-
-const stack = {
-  en: { built: 'Built with', hosted: 'Hosted on GitHub Pages', tagline: 'Made with curiosity in' },
-  tr: { built: 'Yapım', hosted: 'GitHub Pages üzerinde', tagline: 'Merakla yapıldı:' },
-}[lang];
 ---
 
 <footer class="border-t border-border mt-24">
@@ -21,19 +16,42 @@ const stack = {
   >
     <div class="space-y-1">
       <div>© {year} {SITE.author}</div>
+      {/* Built-with / hosted line — TR word order needs the Astro link in
+          front, so we branch the JSX instead of trying to glue fragments
+          from the dictionary. */}
       <div>
-        {stack.built}
-        <a
-          href="https://astro.build"
-          class="hover:text-accent-1"
-          target="_blank"
-          rel="noopener">Astro</a
-        >
-        · {stack.hosted}
+        {
+          lang === 'tr' ? (
+            <>
+              <a
+                href="https://astro.build"
+                class="hover:text-accent-1"
+                target="_blank"
+                rel="noopener">Astro</a> ile yapıldı · GitHub Pages üzerinde barındırılıyor
+            </>
+          ) : (
+            <>
+              Built with <a
+                href="https://astro.build"
+                class="hover:text-accent-1"
+                target="_blank"
+                rel="noopener">Astro</a> · Hosted on GitHub Pages
+            </>
+          )
+        }
       </div>
     </div>
+    {/* Tagline — same word-order story: in TR "Türkiye" comes first
+        ("Türkiye'de merakla yapıldı"), in EN it comes last
+        ("Made with curiosity in Türkiye"). */}
     <div class="text-text-300">
-      {stack.tagline} <span class="text-accent-1">Türkiye</span>
+      {
+        lang === 'tr' ? (
+          <><span class="text-accent-1">Türkiye</span>’de merakla yapıldı</>
+        ) : (
+          <>Made with curiosity in <span class="text-accent-1">Türkiye</span></>
+        )
+      }
     </div>
   </div>
 </footer>

--- a/src/content/blog/april-2026-developer-update-tr.mdx
+++ b/src/content/blog/april-2026-developer-update-tr.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Nisan 2026 Geliştirici Güncellemesi"
-description: "Nisan ayında üzerinde çalıştıklarımın hızlı bir özeti — video formatında."
+description: "Nisan ayında neler yaptığımın kısa özeti — video olarak."
 pubDate: 2026-05-04
 tags: ["devlog", "aylık", "video"]
 heroImage: ../../assets/blog/april-2026.png
@@ -8,8 +8,8 @@ lang: tr
 ---
 import LiteYouTube from '@components/LiteYouTube.astro';
 
-Nisan ayının kısa özeti — yazmaktansa göstermek daha kolaydı.
+Nisan ayında neler yaptığımın hızlı bir özeti — yazmaktansa göstermek daha kolay geldi.
 
 <LiteYouTube id="sePnGxZ2Sdg" title="Nisan 2026 Geliştirici Güncellemesi" />
 
-Görüşmek üzere.
+Gelecek ay görüşürüz.

--- a/src/content/blog/welcome-tr.md
+++ b/src/content/blog/welcome-tr.md
@@ -1,24 +1,24 @@
 ---
 title: "Tanışın: Kaan"
-description: "Kaan Usta'ya bir tanışma yazısı — oyun geliştiricisi, Unity uzmanı ve bu sitenin geri kalanını dolduran işlerin sahibi."
+description: "Kaan Usta'ya bir tanıtım yazısı — oyun geliştiricisi, Unity uzmanı; bu sitenin geri kalanını dolduran işlerin de sahibi."
 pubDate: 2026-04-16
 tags: ["tanıtım", "site"]
 heroImage: ../../assets/portrait.png
 lang: tr
 ---
 
-Bu, kaanusta.dev'in ilk yazısı — ve Kaan tarafından yazılmayacak az sayıdaki yazıdan biri. Bu siteyi birlikte inşa ettik (ben Claude, Anthropic'in yapay zekası), bu yüzden tanıtma sırasını ben aldım.
+Bu, kaanusta.dev'in ilk yazısı — ve Kaan'ın yazmadığı az sayıdaki yazıdan biri. Bu siteyi birlikte kurduk (ben Claude, Anthropic'in yapay zekasıyım); ben de tanıtım yazısını üstüme aldım.
 
 ## Tanışın: Kaan
 
-Yusuf Kaan Usta, Türkiye'de yaşayan bir oyun geliştiricisi. 2020'de Dijital Oyun Tasarımı lisansıyla başladı; programlamaya ve oyun motorlarına duyduğu merak, mobil, PC ve VR'da oyun gönderdiği altı yılı aşkın bir koşuya dönüştü.
+Yusuf Kaan Usta, Türkiye'de yaşayan bir oyun geliştiricisi. 2020'de Dijital Oyun Tasarımı bölümünden mezun oldu; programlamaya ve oyun motorlarına duyduğu merak zamanla mesleğine dönüştü. O günden bu yana mobil, PC ve VR'da altı yılı aşan bir süredir oyun çıkarıyor.
 
-İşleriyle vakit geçirince ortaya çıkan tek bir şey var: **zevk**. Her projesi tutarlı olacak kadar küçük, keyifli olacak kadar cilalı ve sahtesini yapması zor bir özenle kurulmuş — *Brick Game*'den (uçtan uca tek başına geliştirdiği, Tetris esintili bir mobil arcade) *Flex Hit*'e (mühendislik işinin doğru hissi yakalayana kadar Unity Physics'i ince ayarlamak olduğu bir VR casual oyun), ve şu an portföyün merkezindeki *Orbs of The Power*'a — beş ay süren, yeni bir orb eklemenin günleri değil dakikaları aldığı modüler bir orb sistemiyle kurulu bir roguelike.
+İşlerine yakından bakınca ortaya çıkan tek bir şey var: **zevk**. Her proje, kendi içinde bütünlük taşıyacak kadar küçük; oynaması keyifli olacak kadar özenli; ve yapay durmayan bir titizlikle kurulmuş. *Brick Game* (uçtan uca tek başına geliştirdiği, Tetris esintili bir mobil arcade), *Flex Hit* (mühendislik kısmının doğru hisse ulaşana dek Unity Physics ayarlamak olduğu bir VR casual oyun) ve şu an portföyün merkezindeki *Orbs of The Power* — beş aylık, yeni bir orb eklemenin günler değil dakikalar aldığı modüler bir orb sistemiyle inşa edilmiş bir roguelike — bunun örnekleri.
 
-Varsayılan olarak Unity ve C# kullanıyor; iş arkadaşlarını iyi seçiyor (hiper-casual sprintlerde 208 Studios, VR işinde deneyimli bir tasarımcı), yan ilgi alanlarında custom engine geliştirme, VR fizik ve ECS mimarisi var. Onu tek cümleyle özetlemem gerekse: gönderebileceği kadar küçük problemleri seçip onları bitiren bir geliştirici.
+Genelde Unity ve C# ile çalışıyor; ekip arkadaşlarını iyi seçiyor (hiper-casual sprintlerde 208 Studios, VR projesinde deneyimli bir tasarımcı). Yan ilgi alanları arasında custom engine geliştirme, VR fizik ve ECS mimarisi var. Tek cümleyle özetlemem gerekirse: bitirebileceği ölçekte problemler seçip onları gerçekten bitiren bir geliştirici.
 
 ## Bu site hakkında
 
-Tek bir akşamda kuruldu. Anlamlı her kararı Kaan verdi — paleti, düzeni, neyin şimdi neyin sonra olacağını — kodu ben yazdım. Stack: Astro 5 + Tailwind 3 + TypeScript, GitHub Pages.
+Tek bir akşamda yapıldı. Önemli her kararı Kaan verdi — paleti, düzeni, neyin şimdi gireceğini neyin beklemeye alınacağını — kodu da ben yazdım. Stack: Astro 5 + Tailwind 3 + TypeScript, GitHub Pages.
 
 — Claude

--- a/src/content/blog/welcome.md
+++ b/src/content/blog/welcome.md
@@ -10,9 +10,9 @@ This is the first post on kaanusta.dev — and one of the few that won't be writ
 
 ## Meet Kaan
 
-Yusuf Kaan Usta is a game developer based in Türkiye. He started in 2020 with a Digital Game Design degree, and what began as curiosity about programming and engines turned into a six-plus-year run shipping games across mobile, PC, and VR.
+Yusuf Kaan Usta is a game developer based in Türkiye. He came out of a Digital Game Design program in 2020, and what started as curiosity about programming and engines turned into a six-plus-year stretch of shipping games across mobile, PC, and VR.
 
-The thing that becomes clear when you spend time on his work is **taste**. Each project is small enough to be coherent, polished enough to be enjoyable, and built with care that's hard to fake — from *Brick Game* (a Tetris-inspired mobile arcade he built end-to-end alone) to *Flex Hit* (a VR casual game where the engineering job was tuning Unity Physics until the feel was right) to *Orbs of The Power* — currently the centerpiece — a five-month roguelike with a modular orb system designed so a new orb takes minutes to add, not days.
+The thing that becomes clear when you spend time with his work is **taste**. Each project is small enough to be coherent, polished enough to be enjoyable, and built with care that's hard to fake — from *Brick Game* (a Tetris-inspired mobile arcade he built end-to-end alone) to *Flex Hit* (a VR casual game where the engineering work was tuning Unity Physics until the feel was right) to *Orbs of The Power* — currently the centerpiece — a five-month roguelike with a modular orb system designed so a new orb takes minutes to add, not days.
 
 He works in Unity and C# by default, picks collaborators well (208 Studios for the hyper-casual sprints, an experienced designer for the VR work), and has side interests in custom engine development, VR physics, and ECS architecture. If I had to summarize him in one line: a developer who picks problems small enough to ship and finishes them.
 

--- a/src/content/projects/brick-game-tr.md
+++ b/src/content/projects/brick-game-tr.md
@@ -5,7 +5,7 @@ genres: ["Casual", "Arcade"]
 year: 2022
 duration: "2 ay"
 role: "Solo (her şey sıfırdan — kod, görseller, UI, SFX)"
-description: "Yeni grafikler, seviyeler ve oyun modlarıyla, Tetris'ten esinlenmiş modern bir mobil oyun. Tüm görseller, UI ve ses efektleri dahil sıfırdan inşa edildi."
+description: "Yeni grafikler, seviyeler ve oyun modlarıyla Tetris esintili modern bir mobil oyun. Tüm görseller, arayüz ve ses efektleri dahil sıfırdan yapıldı."
 techStack: ["Unity", "C#"]
 links:
   github: "https://github.com/KaanEkimoz/Brick-Game"
@@ -20,12 +20,12 @@ order: 2
 lang: tr
 ---
 
-Tetris esintili arcade formatına modern bir bakış — uçtan uca tek başına geliştirildi: kod, sanat, UI ve ses efektleri. Boş bir Unity projesinden, birden fazla oyun modu içeren cilalı bir mobil sürüme iki ayda ulaşıldı.
+Tetris esintili arcade formatına modern bir bakış. Tek başıma, baştan sona geliştirdim: kod, görsel, arayüz, ses efektleri. Boş bir Unity projesinden birden fazla oyun modu içeren cilalı bir mobil sürüme iki ayda ulaştım.
 
-"Her şeyi kendin yap" kısıtının kendisi mesele. UI tasarlamak, programcıların genelde görmediği şeyleri öğretti; Audacity'de SFX kesmek, ses tasarımcılarının gerçekte ne yaptığını gösterdi.
+"Her şeyi kendin yap" kısıtının kendisi olayın özüydü. Arayüz tasarlamak, programcıların çoğu zaman görmediği şeyleri öğretti; Audacity'de SFX kesmek de ses tasarımcılarının gerçekte ne yaptığını gösterdi.
 
 ## Yapım notları
 
-- Tüm görseller kod ya da basit primitivelerle kuruldu — üçüncü taraf varlık kullanılmadı.
-- Tabloda tasarlanan ilerleme eğrileriyle özel bir seviye sistemi.
-- Audacity'de, public-domain örnekleri temel alarak sıfırdan ses tasarımı.
+- Tüm görsel kodla ya da basit primitive'lerle yapıldı; üçüncü taraf asset kullanılmadı.
+- Spreadsheet'lerde tasarladığım ilerleme eğrileriyle çalışan, özel bir seviye sistemi.
+- Audacity'de, public-domain örnekleri taban alarak sıfırdan yapılmış ses tasarımı.

--- a/src/content/projects/brick-game.md
+++ b/src/content/projects/brick-game.md
@@ -5,7 +5,7 @@ genres: ["Casual", "Arcade"]
 year: 2022
 duration: "2 Months"
 role: "Solo (everything from scratch — code, visuals, UI, SFX)"
-description: "A modern Tetris-inspired mobile game with new graphics, levels, and gamemodes. Built entirely from scratch including all visuals, UI, and sound effects."
+description: "A modern Tetris-inspired mobile game with new graphics, levels, and game modes. Built entirely from scratch including all visuals, UI, and sound effects."
 techStack: ["Unity", "C#"]
 links:
   github: "https://github.com/KaanEkimoz/Brick-Game"

--- a/src/content/projects/draw-rush-tr.md
+++ b/src/content/projects/draw-rush-tr.md
@@ -19,6 +19,6 @@ order: 4
 lang: tr
 ---
 
-208 Studios'ta iki haftalık bir sprint. Hiper-casual brief: çizim tabanlı mobil bulmaca, 30 saniyede bağımlılık yapan, retention testi için yeterince cilalı.
+208 Studios'ta iki haftalık bir sprint. Hiper-casual brief'i şuydu: çizim tabanlı bir mobil bulmaca olacak, 30 saniyede bağımlılık yapacak ve retention testine girebilecek kadar cilalı olacaktı.
 
-Hiper-casual bir kısıt disiplini. Her sistemin 5 saniyede anlaşılır, 5 dakikada tatmin edici ve 5 günde gönderilebilir olması gerekiyor. Mimari hile: her şeyi gevşek bağlı tutup tasarım ekibinin parametreleri yeniden build almadan canlıya alabilmesini sağlamak.
+Hiper-casual bir kısıt disiplinidir. Her sistemin 5 saniyede anlaşılır, 5 dakikada tatmin edici ve 5 günde gönderilebilir olması gerekir. Mimari hilesi şu: her şeyi gevşek bağlı tutmak; böylece tasarım ekibi parametreleri yeniden build almadan canlıya alabilsin.

--- a/src/content/projects/flex-hit-tr.md
+++ b/src/content/projects/flex-hit-tr.md
@@ -5,7 +5,7 @@ genres: ["Casual"]
 year: 2023
 duration: "2 ay"
 role: "Tek geliştirici (deneyimli bir tasarımcıyla günlük iş birliği)"
-description: "Unity Physics hakimiyetinin oynanış hissinin merkezinde olduğu bir VR casual oyun. Erişilebilirlik ve kısa oturumlar için tasarlandı."
+description: "Oynanış hissinin tamamen Unity Physics ustalığına bağlı olduğu bir VR casual oyun. Erişilebilirlik ve kısa oturumlar düşünülerek tasarlandı."
 techStack: ["Unity", "Unity XR", "C#", "Unity Physics"]
 links: {}
 coverImage: "../../assets/projects/flex-hit/cover.png"
@@ -18,12 +18,12 @@ order: 3
 lang: tr
 ---
 
-Her şeyin fizik hissine indiği bir VR casual oyun. Brief basitti — erişilebilir olsun, çabuk öğrenilsin, vuruşları tatmin edici hissetsin — ama altta yatan Unity Physics ince ayarı işin tamamıydı.
+Her şeyin fizik hissine indiği bir VR casual oyun. Brief basitti — erişilebilir olacak, çabuk öğrenilecek, vuruşlar tatmin edici hissedilecek — ama altta yatan Unity Physics ince ayarı işin tamamıydı.
 
-Deneyimli bir tasarımcıyla günlük çalışmak, VR'a bakışımı değiştirdi. Donanım göz ardı edilemeyecek kısıtlar getiriyor: fiziksel yorgunluk, mevcudiyet hissi, konfor. Her etkileşim başlık takılı halde test edildi, her iterasyon "yeni bir oyuncu kolları yorulana kadar ne kadar oynayabiliyor?" ölçütüyle ölçüldü.
+Deneyimli bir tasarımcıyla her gün çalışmak, VR'a bakışımı değiştirdi. Donanım göz ardı edilemeyecek kısıtlar getiriyor: fiziksel yorgunluk, presence hissi, konfor. Her etkileşim başlık takılı halde test edildi; her iterasyon "yeni bir oyuncu kolları yorulana kadar ne kadar oynayabiliyor?" sorusuyla ölçüldü.
 
 ## VR bana ne öğretti
 
-- **Fizik ≠ gerçekçilik.** VR hissi simüle edilmez, ince ayarlanır.
-- **Erişilebilirlik tasarımdır, kutucuk değil.** Oturarak mod, boy kalibrasyonu, konfor seçenekleri.
-- **Sürekli başlıkta test et.** Sadece editörde iterasyon yalan söyler.
+- **Fizik ≠ gerçekçilik.** VR hissi simüle edilmiyor, ince ayarlanıyor.
+- **Erişilebilirlik bir tasarım kararıdır, kutucuk değil.** Oturarak oynama modu, boy kalibrasyonu, konfor seçenekleri.
+- **Sürekli başlıkta test et.** Yalnızca editörde iterasyon insanı yanıltır.

--- a/src/content/projects/orbs-of-the-power-tr.md
+++ b/src/content/projects/orbs-of-the-power-tr.md
@@ -5,7 +5,7 @@ genres: ["Roguelike", "Action", "Isometric"]
 year: 2025
 duration: "5 ay"
 role: "Tek geliştirici (tasarımcı + 3D sanatçı iş birliğiyle)"
-description: "Beş benzersiz orb ve dinamik dövüş mekanikleri etrafında kurulu, modüler bir roguelike aksiyon oyunu. Her orb farklı yetenekler taşır; birleştiklerinde yeni oynanış tarzları ortaya çıkar."
+description: "Beş farklı orb ve dinamik dövüş mekanikleri etrafına inşa edilmiş, modüler bir roguelike aksiyon oyunu. Her orbun ayrı bir yeteneği var; birleştiklerinde yepyeni oynanış tarzları ortaya çıkıyor."
 techStack: ["Unity", "C#", "ECS-style architecture"]
 links:
   github: "https://github.com/KaanEkimoz/Orbs-of-The-Power"
@@ -19,12 +19,12 @@ order: 1
 lang: tr
 ---
 
-Beş ay boyunca tek başına geliştirilmiş bir roguelike aksiyon oyunu. Temel fantezi: her birinin farklı bir yeteneği olan beş orb, her koşuda birleşerek yeni oynanış tarzları doğuruyor.
+Beş ay boyunca tek başıma geliştirdiğim bir roguelike aksiyon oyunu. Temel fantezi şu: her biri farklı bir yeteneğe sahip beş orb, her koşuda birleşip farklı oynanış tarzları doğuruyor.
 
-Mimari, ECS tarzı bir ayrışmaya yaslanıyor — bileşenler veri, sistemler davranış ve orblar yalnızca konfigürasyon. Yeni bir orb eklemek günler değil dakikalar alıyor.
+Mimari, ECS tarzı bir ayrışmaya dayanıyor — bileşenler veri, sistemler davranış, orblar ise sadece konfigürasyon. Yeni bir orb eklemek artık günler değil dakikalar sürüyor.
 
 ## Ne öğrendim
 
-- **Modüler dövüş şaşırtıcı şekilde ölçekleniyor.** Yapı taşları küçük olduğunda, bir öğle sonrası çılgın bir yeni kombo prototiplenip sonraki sprintte gönderilebiliyor.
-- **Roguelike tempo acımasız.** Beş dakikalık koşuları, saatlerce sürecek bir derinlikle dengelemek başlı başına bir mühendislik problemi.
-- **Tek geliştirici + iş arkadaşları tatlı bir nokta** — sistemler için tasarımcı, varlıklar için 3D sanatçı, derlenen her şey için ben.
+- **Modüler dövüş şaşırtıcı biçimde ölçekleniyor.** Yapı taşları küçük olunca, bir öğleden sonrada çılgınca yeni bir kombo prototiplenip bir sonraki sprintte gönderilebiliyor.
+- **Roguelike tempo acımasız.** Beş dakikalık koşuları saatlerce sürecek bir derinlikle dengelemek başlı başına bir mühendislik problemi.
+- **Tek geliştirici + iş arkadaşları ideal bir denge** — sistemler için tasarımcı, varlıklar için 3D sanatçı, derlenen her şey için ben.

--- a/src/content/projects/stack-runner-tr.md
+++ b/src/content/projects/stack-runner-tr.md
@@ -5,7 +5,7 @@ genres: ["Hyper-casual"]
 year: 2022
 duration: "2 hafta"
 role: "Tek geliştirici (tasarımcı + 3D sanatçıyla birlikte)"
-description: "Stackball mekaniğini endless runner oynanışıyla birleştiriyor. 208 Studios'ta inşa edildi."
+description: "Stackball mekaniğini endless runner oynanışıyla birleştiren bir mobil oyun. 208 Studios'ta yapıldı."
 techStack: ["Unity", "C#"]
 links:
   github: "https://github.com/KaanEkimoz/Stackball-Runner"
@@ -19,6 +19,6 @@ order: 5
 lang: tr
 ---
 
-208 Studios'ta iki haftalık başka bir sprint — bu sefer stackball çarpma döngüsünü endless runner temposuyla birleştirdik. Tasarım hipotezi: bilinen tatmin edici bir çekirdeği (yığınları parçalamak) alıp daha uzun bir oturum döngüsüne uzatmak.
+208 Studios'ta bir başka iki haftalık sprint — bu sefer stackball çarpma döngüsünü endless runner temposuyla birleştirdik. Tasarım hipotezi şuydu: tatmin edici, herkesin bildiği bir çekirdek mekaniği (yığınları parçalamak) alıp onu daha uzun bir oturum döngüsüne uzatmak.
 
-Prosedürel seviye üretimi, zorluk ölçekleme ve tepkili kamera işi mühendisliğin merkeziydi. Hiper-casual runner'larda zorluk: kamerayı "hızlı" hissettirirken ucuz telefonlarda oyuncuyu midesi bulanmayacak şekilde tutmak.
+Prosedürel seviye üretimi, zorluk ölçekleme ve tepkili kamera çalışması mühendisliğin merkezindeydi. Hiper-casual runner'larda asıl zorluk şu: kamerayı "hızlı" hissettireceksin, ama ucuz telefonlarda oyuncunun midesini bulandırmadan.

--- a/src/content/projects/still-tr.md
+++ b/src/content/projects/still-tr.md
@@ -5,7 +5,7 @@ genres: ["Puzzle"]
 year: 2021
 duration: "3 gün (Game Jam)"
 role: "2 geliştirici + 1 sanatçı ekibi"
-description: "Bir game jam için 3 günde inşa edilen mini bulmaca mobil oyunu. Birden fazla kısa bulmacaya sahip, kompakt ve odaklı bir oynanış."
+description: "Bir game jam için 3 günde yapılmış mini bir bulmaca mobil oyunu. Birden fazla kısa bulmaca içeren, kompakt ve odaklı bir oynanış."
 techStack: ["Unity", "C#"]
 links: {}
 coverImage: "../../assets/projects/still/cover.png"
@@ -17,12 +17,12 @@ order: 6
 lang: tr
 ---
 
-3 günlük bir game jam yapımı. İki geliştirici ve bir sanatçıdan oluşan ekip; tutarlı bir şey gönderebilmek için saatle yarış.
+3 günlük bir game jam yapımı. İki geliştirici ve bir sanatçıdan oluşan ekiple, tutarlı bir şey çıkarabilmek için saatle yarıştık.
 
-Game jam'ler bir tür mimari dürüstlüğü zorunlu kılıyor: aşırı mühendisliğe vakit yok, ama dağınıklığa da yer yok. Minimal bir bulmaca iskeletinde karar kıldık — her bulmaca bir sahne, her sahne minik bir input/animasyon/state çekirdeğini paylaşıyor; bütün şey birkaç yüz satıra sığıyor.
+Game jam'ler bir tür mimari dürüstlüğü zorunlu kılıyor: aşırı mühendislik için vakit yok, ama dağınıklığa da yer yok. Minimal bir bulmaca iskeletinde karar kıldık — her bulmaca bir sahne, her sahne küçük bir input/animasyon/state çekirdeğini paylaşıyor; tüm proje birkaç yüz satıra sığdı.
 
 ## Jam'ler ne öğretir
 
-- **Tek önemli düğme kapsamdır.** Sıkıcı bir şey seç ve bitir.
-- **50 yerine 5 şeyi cilala.** Üç sağlam bulmacalı bir jam yapımı, on iki bozuk bulmacalı bir yapımı yener.
-- **Uyku da takvimin parçasıdır.** Yorgunken eğlenceli oyun gönderemezsin.
+- **Tek önemli düğme kapsam.** Sıkıcı bir şey seç ve bitir.
+- **50 değil 5 şeyi cilala.** Üç sağlam bulmacalı bir jam yapımı, on iki bozuk bulmacalı bir yapımı her zaman yener.
+- **Uyku da takvimin bir parçası.** Yorgunken eğlenceli oyun çıkmaz.

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -137,7 +137,7 @@ const tr: Dict = {
     eyebrow: '/// PORTFOLYO · BLOG',
     role: 'OYUN GELİŞTİRİCİSİ',
     description:
-      '2020’den beri mobil oyunlar geliştiriyor. Unity uzmanı; hafif ve bağımlılık yapan deneyimlere odaklanır.',
+      '2020’den beri mobil oyunlar çıkarıyor. Unity üzerine uzmanlaşmış; hafif ve kolay bağımlılık yapan deneyimlere odaklanıyor.',
     cta: { viewProjects: '[ Projeleri Gör ]', readBlog: '[ Blogu Oku ]' },
     scroll: 'KAYDIR',
   },
@@ -149,9 +149,9 @@ const tr: Dict = {
   },
   about: {
     title: 'Hakkında',
-    p1: '2020’den beri yazılım ve oyun geliştirme dünyasının içindeyim. Yolculuğum Dijital Oyun Tasarımı lisansıyla başladı — programlamaya ve oyun motorlarına duyduğum merak, zamanla asıl odağım oldu.',
-    p2: `Mobil, PC ve VR’a uzanan projelerde çalıştım; ama uzmanlığımı <span class="text-text-100">mobil oyun geliştirme</span> üzerinde derinleştirmeyi tercih ettim. İki haftada kurulan hiper-casual prototiplerden, beş ay boyunca geliştirilen roguelike sistemlere kadar tüm yelpazeyi seviyorum: oynanış programlaması, sistem tasarımı ve bir oyunu canlı hissettiren küçük ayrıntılar.`,
-    p3: `Şu anda <span class="text-accent-1">Unity</span> ve <span class="text-accent-1">C#</span> üzerine yoğunlaşıyorum; yan ilgi alanlarımda custom engine işleri, VR fizik ve ECS mimarisi var.`,
+    p1: '2020’den bu yana yazılım ve oyun geliştirme dünyasının içindeyim. Yolculuğum üniversitede Dijital Oyun Tasarımı okuyarak başladı — programlamaya ve oyun motorlarına duyduğum merak, zamanla asıl odağım haline geldi.',
+    p2: `Mobil, PC ve VR’a uzanan projelerde çalıştım; ama uzmanlığımı <span class="text-text-100">mobil oyun geliştirme</span> tarafında derinleştirmeyi tercih ettim. İki haftada yapılan hiper-casual prototiplerden beş ay boyunca geliştirdiğim roguelike sistemlere kadar bu işin tüm yelpazesini seviyorum: oynanış programlaması, sistem tasarımı ve bir oyunu yaşatan o küçük ayrıntılar.`,
+    p3: `Şu sıralar <span class="text-accent-1">Unity</span> ve <span class="text-accent-1">C#</span> üzerine yoğunlaşıyorum. Yan tarafta custom engine geliştirme, VR fizik ve ECS mimarisiyle ilgileniyorum.`,
   },
   featured: { title: 'Öne Çıkan Projeler', seeAll: '[ Tüm Projeler → ]' },
   latest: { title: 'Son Yazılar', allPosts: '[ Tüm Yazılar → ]', empty: 'Yakında.' },
@@ -166,7 +166,7 @@ const tr: Dict = {
   projectsIndex: {
     title: 'Projeler',
     subtitle:
-      'Mobil, PC ve VR oyun ve prototip seçkisi — iki haftalık hiper-casual sprintlerden jam yapımlarına ve aylar süren roguelike sistemlere uzanır.',
+      'Mobil, PC ve VR’dan bir oyun ve prototip seçkisi — iki haftalık hiper-casual sprintlerden game jam yapımlarına, aylarca süren roguelike sistemlere kadar uzanıyor.',
   },
   projectDetail: {
     back: '← Projelere Dön',
@@ -184,7 +184,7 @@ const tr: Dict = {
     // "GAME OVER" stays as proper-noun gaming reference — Turkish gamers
     // recognize it directly and the iconography is the point.
     gameOver: 'GAME OVER',
-    body: 'Aradığın sayfa yok — belki kırık bir link, belki hiç yayınlanmamış bir sayfa.',
+    body: 'Aradığın sayfa burada yok — kırık bir link ya da hiç yayımlanmamış bir sayfa olabilir.',
     restart: '[ YENİDEN BAŞLA ]',
   },
   toggle: { theme: 'Temayı değiştir', language: 'Dili değiştir' },
@@ -199,10 +199,10 @@ const tr: Dict = {
   meta: {
     siteTitle: 'Kaan Usta — Oyun Geliştirici',
     siteDescription:
-      '2020’den beri mobil oyunlar geliştiriyor. Unity uzmanı; hafif ve bağımlılık yapan deneyimlere odaklanır.',
+      '2020’den beri mobil oyunlar çıkarıyor. Unity üzerine uzmanlaşmış; hafif ve kolay bağımlılık yapan deneyimlere odaklanıyor.',
     blogTitle: 'Blog',
     blogDescription:
-      'Kaan Usta’dan oyun geliştirme üzerine devloglar, post-mortem’ler ve notlar.',
+      'Kaan Usta’nın oyun geliştirme üzerine devlogları, post-mortem’leri ve notları.',
     projectsTitle: 'Projeler',
     projectsDescription:
       'Kaan Usta’nın oyun ve prototipleri — mobil, PC ve VR.',


### PR DESCRIPTION
## Summary
The first-pass Turkish translations read like literal English. Phrases like \"Dijital Oyun Tasarımı lisansıyla başladı\", \"varsayılan olarak Unity kullanıyor\", \"tatlı bir nokta\" and \"gönderdiği koşuya dönüştü\" land as calques, not Turkish.

This PR rewrites every TR string to flow as a native speaker would write it, and polishes a few EN edges that were brought up in the same pass.

### TR changes
- **i18n.ts**: hero/meta descriptions, about p1/p2/p3, projectsIndex subtitle, 404 body — all reworked. Key swaps: \`lisansıyla başladı → üniversitede ... okuyarak başladı\`; \`varsayılan olarak → şu sıralar\`; \`canlı hissettiren → yaşatan\`; passive constructions → active.
- **Footer.astro**: the old \`{built} <Astro> · {hosted}\` template produced \"Yapım Astro · GitHub Pages üzerinde\" in TR. Branch the JSX per locale so TR reads \"Astro ile yapıldı · GitHub Pages üzerinde barındırılıyor\" and the tagline reads \"Türkiye'de merakla yapıldı\" with the accent span in front.
- **welcome-tr.md**: full rewrite, third-person Claude voice preserved.
- **april-2026-developer-update-tr.mdx** and all 6 project \`-tr.md\` files: descriptions and bodies reworked. \"tatlı bir nokta\" → \"ideal bir denge\", \"uçtan uca tek başına\" → \"tek başıma baştan sona\", \"mevcudiyet hissi\" → \"presence hissi\", etc.

### EN polish
- **welcome.md**: \`started in 2020 with a Digital Game Design degree\` → \`came out of a Digital Game Design program in 2020\`; \`spend time on\` → \`spend time with\`; \`engineering job\` → \`engineering work\`.
- **brick-game.md**: \`gamemodes\` → \`game modes\`.

## Test plan
- [x] /tr/ hero, about paragraphs, footer all read as idiomatic Turkish
- [x] /tr/blog/welcome body flows naturally
- [x] /tr/projects/orbs-of-the-power description + body reworded
- [x] EN tweaks visible on /
- [x] Verified at localhost:4321 in Chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)