### PR TITLE
content(projects): swap Brick Game video

### DIFF
--- a/src/content/projects/brick-game-tr.md
+++ b/src/content/projects/brick-game-tr.md
@@ -15,7 +15,7 @@ gallery:
   - "../../assets/projects/brick-game/cover.png"
   - "../../assets/projects/brick-game/gallery/01.png"
   - "../../assets/projects/brick-game/gallery/02.png"
-youtubeId: "C_O8qqyZQSA"
+youtubeId: "8HeRix3L7K0"
 featured: true
 order: 2
 lang: tr

--- a/src/content/projects/brick-game.md
+++ b/src/content/projects/brick-game.md
@@ -15,7 +15,7 @@ gallery:
   - "../../assets/projects/brick-game/cover.png"
   - "../../assets/projects/brick-game/gallery/01.png"
   - "../../assets/projects/brick-game/gallery/02.png"
-youtubeId: "C_O8qqyZQSA"
+youtubeId: "8HeRix3L7K0"
 featured: true
 order: 2
 ---


### PR DESCRIPTION
Replace the Brick Game youtubeId with the newer Shorts recording (8HeRix3L7K0). Embed stays in the existing 16:9 frame — letterboxed Short is fine per Kaan's preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)