### PR TITLE
content(brick-game): rewrite copy around current build + monetization

### DIFF
--- a/src/content/projects/brick-game-tr.md
+++ b/src/content/projects/brick-game-tr.md
@@ -4,9 +4,9 @@ platform: Mobile
 genres: ["Casual", "Arcade"]
 year: 2022
 duration: "2 ay"
-role: "Solo (her şey sıfırdan — kod, görseller, UI, SFX)"
-description: "Yeni grafikler, seviyeler ve oyun modlarıyla Tetris esintili modern bir mobil oyun. Tüm görseller, arayüz ve ses efektleri dahil sıfırdan yapıldı."
-techStack: ["Unity", "C#"]
+role: "Solo (kod, görsel, arayüz, ses, monetizasyon)"
+description: "Tek başına baştan sona geliştirilmiş, cilalı bir mobil blok puzzle."
+techStack: ["Unity", "C#", "LevelPlay (ironSource)", "Unity IAP"]
 links:
   github: "https://github.com/KaanEkimoz/Brick-Game"
   googlePlay: "https://play.google.com/store/apps/details?id=com.ekimozgames.brickgame"
@@ -24,12 +24,17 @@ order: 2
 lang: tr
 ---
 
-Tetris esintili arcade formatına modern bir bakış. Tek başıma, baştan sona geliştirdim: kod, görsel, arayüz, ses efektleri. Boş bir Unity projesinden birden fazla oyun modu içeren cilalı bir mobil sürüme iki ayda ulaştım.
+Düşen-blok arcade formatına modern bir bakış — çekirdek mekanik blok yığma; Classic modunun yanında Bomb ve Laser yetenekleri ekleyen bir Extended mod var. Çapraz platform (Android yayında, iOS başvuru aşamasında).
 
-"Her şeyi kendin yap" kısıtının kendisi olayın özüydü. Arayüz tasarlamak, programcıların çoğu zaman görmediği şeyleri öğretti; Audacity'de SFX kesmek de ses tasarımcılarının gerçekte ne yaptığını gösterdi.
+## Teknik öne çıkanlar
 
-## Yapım notları
+- Sürümlü migration'lar ve 7-bag parça randomizer'ı içeren özel save sistemi.
+- LevelPlay reklamlar + Unity IAP entegrasyonu, restore-purchases akışıyla birlikte.
+- 5 aşamalı zorluk eğrisi, lock-delay tuning, hard/soft-drop fizik.
+- Restart-state sızıntıları için bug-hunting turları (HUD, level, bag, ability buffer).
 
-- Tüm görsel kodla ya da basit primitive'lerle yapıldı; üçüncü taraf asset kullanılmadı.
-- Spreadsheet'lerde tasarladığım ilerleme eğrileriyle çalışan, özel bir seviye sistemi.
-- Audacity'de, public-domain örnekleri taban alarak sıfırdan yapılmış ses tasarımı.
+## Süreç notları
+
+- Tüm görseller engine içinde yapıldı — üçüncü taraf sanat asset'i kullanılmadı.
+- SFX, Audacity'de public-domain örnekler üzerinden sıfırdan kesildi.
+- Level temposu, koda dökülmeden önce spreadsheet simülasyonlarıyla ince ayarlandı.

--- a/src/content/projects/brick-game.md
+++ b/src/content/projects/brick-game.md
@@ -3,10 +3,10 @@ title: "Brick Game"
 platform: Mobile
 genres: ["Casual", "Arcade"]
 year: 2022
-duration: "2 Months"
-role: "Solo (everything from scratch — code, visuals, UI, SFX)"
-description: "A modern Tetris-inspired mobile game with new graphics, levels, and game modes. Built entirely from scratch including all visuals, UI, and sound effects."
-techStack: ["Unity", "C#"]
+duration: "2 months"
+role: "Solo (code, visuals, UI, SFX, monetization)"
+description: "A polished mobile block-puzzle, built solo end-to-end."
+techStack: ["Unity", "C#", "LevelPlay (ironSource)", "Unity IAP"]
 links:
   github: "https://github.com/KaanEkimoz/Brick-Game"
   googlePlay: "https://play.google.com/store/apps/details?id=com.ekimozgames.brickgame"
@@ -23,12 +23,17 @@ featured: true
 order: 2
 ---
 
-A modern take on the Tetris-inspired arcade format, built solo end-to-end — code, art, UI, and sound effects. Two months from blank Unity project to a polished mobile build with multiple game modes.
+A modern take on the falling-block arcade format — block-stacking core with a Classic mode plus an Extended mode that adds Bomb and Laser abilities. Cross-platform (Android live, iOS in submission).
 
-The constraint of "do everything yourself" was the point. Designing UI taught me what programmers usually don't see; cutting SFX in Audacity taught me what audio designers actually do.
+## Engineering highlights
 
-## Build notes
+- Custom save system with versioned migrations + 7-bag piece randomizer.
+- LevelPlay ads + Unity IAP integration with a restore-purchases flow.
+- 5-stage difficulty curve, lock-delay tuning, hard/soft-drop physics.
+- Bug-hunting passes for restart-state leaks (HUD, level, bag, ability buffer).
 
-- All visuals built in code or simple primitives — no third-party assets.
-- Custom level system with progression curves designed in spreadsheets.
-- Sound design done from scratch in Audacity with public-domain samples as a base.
+## Process notes
+
+- All visuals built in-engine — no third-party art assets.
+- SFX cut from scratch in Audacity over public-domain samples.
+- Level pacing tuned via spreadsheet sims before code.


### PR DESCRIPTION
Refresh the Brick Game project page so it describes what the project is *now* — a polished cross-platform release with Classic + Extended (Bomb/Laser) modes, ads/IAP integration, save migrations, a tuned difficulty curve — instead of the original 2022 trailer story.

- Frontmatter: shorter tagline description, role includes monetization, techStack adds LevelPlay (ironSource) + Unity IAP, duration normalized.
- Body: new intro paragraph plus 'Engineering highlights' and 'Process notes' sections (replacing the previous Build notes block).
- TR mirror rewritten in idiomatic Turkish with the technical loanwords preserved.
- iOS App Store link deliberately omitted — URL doesn't exist yet; intro covers iOS submission status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)