### PR TITLE
fix(projects): exclude cover image from Screenshots section

### DIFF
--- a/src/pages/projects/[...slug].astro
+++ b/src/pages/projects/[...slug].astro
@@ -39,10 +39,13 @@ const {
 const platformVariant =
   platform === 'Mobile' ? 'cyan' : platform === 'PC' ? 'magenta' : 'amber';
 
-const screenshots =
-  coverImage && !gallery.some((g) => g.src === coverImage.src)
-    ? [coverImage, ...gallery]
-    : gallery;
+// Cover image is the card hero only — it's a branded marketing asset, not
+// a screenshot, so it never belongs in the Screenshots grid (mixed aspect
+// ratios looked off, and most projects already list cover.png in `gallery`
+// from earlier data). Filter it out by `.src` if present.
+const screenshots = coverImage
+  ? gallery.filter((g) => g.src !== coverImage.src)
+  : gallery;
 ---
 
 <BaseLayout lang={lang} title={title} description={description}>

--- a/src/pages/tr/projects/[...slug].astro
+++ b/src/pages/tr/projects/[...slug].astro
@@ -38,10 +38,13 @@ const {
 const platformVariant =
   platform === 'Mobile' ? 'cyan' : platform === 'PC' ? 'magenta' : 'amber';
 
-const screenshots =
-  coverImage && !gallery.some((g) => g.src === coverImage.src)
-    ? [coverImage, ...gallery]
-    : gallery;
+// Cover image is the card hero only — it's a branded marketing asset, not
+// a screenshot, so it never belongs in the Screenshots grid (mixed aspect
+// ratios looked off, and most projects already list cover.png in `gallery`
+// from earlier data). Filter it out by `.src` if present.
+const screenshots = coverImage
+  ? gallery.filter((g) => g.src !== coverImage.src)
+  : gallery;
 ---
 
 <BaseLayout lang={lang} title={title} description={description}>


### PR DESCRIPTION
Cover image is the card hero / marketing graphic — not a screenshot. The slug template previously auto-prepended it and also let it through when projects had cover.png as gallery[0]. Now it's filtered out by `.src` for both EN and TR slug routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)