### PR TITLE
feat(projects): Published filter pill alongside platform pills

### DIFF
--- a/src/components/ProjectFilter.astro
+++ b/src/components/ProjectFilter.astro
@@ -2,26 +2,33 @@
 /**
  * ProjectFilter
  *
- * Pills above the /projects grid that filter cards by platform.
- * Filtering is client-side — every card on the page carries a
- * data-platform attribute; the script toggles `hidden` on the
- * non-matching ones and mirrors the choice in the URL as
- * `?platform=mobile` so a filtered view is shareable.
+ * Pills above the /projects grid that narrow the catalog.
  *
- * Only platforms that actually have a project show up as pills;
- * we don't render an empty "Web" pill just because the enum
- * allows it.
+ * Two filter dimensions live in the same row:
+ * - **Platform** pills (Mobile / PC / VR / Web) — only the platforms
+ *   with at least one project show up, in a fixed natural order.
+ * - **Published** pill — only shown if at least one project is
+ *   actually shipped on a store. Sits AFTER the platform pills so
+ *   the row reads platforms → status.
+ *
+ * Filtering is client-side: every card carries a `data-project-platform`
+ * attribute, and published cards additionally carry
+ * `data-project-published="true"`. The current pill choice is mirrored
+ * in the URL as `?platform=<value>` (kept for backward compat with the
+ * earlier platform-only version) so a filtered view is shareable.
  */
 import { DEFAULT_LOCALE, t, type Lang } from '@lib/i18n';
 
 interface Props {
   /** Platforms that have at least one project, in the order to render. */
   platforms: Array<'Mobile' | 'PC' | 'VR' | 'Web'>;
-  /** Locale — drives the "All" label and aria text. */
+  /** Render the Published pill — only when there's at least one published project. */
+  showPublished?: boolean;
+  /** Locale — drives pill labels + aria text. */
   lang?: Lang;
 }
 
-const { platforms, lang = DEFAULT_LOCALE } = Astro.props;
+const { platforms, showPublished = false, lang = DEFAULT_LOCALE } = Astro.props;
 
 const variantFor: Record<string, string> = {
   Mobile: 'cyan',
@@ -59,6 +66,19 @@ const variantFor: Record<string, string> = {
       </button>
     ))
   }
+  {
+    showPublished && (
+      <button
+        type="button"
+        class="filter-pill"
+        data-value="published"
+        data-variant="status"
+        aria-pressed="false"
+      >
+        {t('projectFilter.published', lang)}
+      </button>
+    )
+  }
 </div>
 
 <style>
@@ -87,15 +107,28 @@ const variantFor: Record<string, string> = {
   .filter-pill[aria-pressed='true'][data-variant='amber'] {
     @apply border-accent-3 text-accent-3;
   }
+  /* Status filter (Published) — picks up a subtle elevated background
+     when active so it reads as "different dimension" instead of just
+     another color-coded platform pill. */
+  .filter-pill[aria-pressed='true'][data-variant='status'] {
+    @apply border-text-100 text-text-100 bg-bg-elev;
+  }
 </style>
 
 <script>
-  type FilterValue = string; // 'all' | platform name
+  type FilterValue = string; // 'all' | platform name | 'published'
 
   function apply(filter: FilterValue) {
     const cards = document.querySelectorAll<HTMLElement>('[data-project-platform]');
     cards.forEach((card) => {
-      const match = filter === 'all' || card.dataset.projectPlatform === filter;
+      let match: boolean;
+      if (filter === 'all') {
+        match = true;
+      } else if (filter === 'published') {
+        match = card.dataset.projectPublished === 'true';
+      } else {
+        match = card.dataset.projectPlatform === filter;
+      }
       card.hidden = !match;
     });
     document.querySelectorAll<HTMLButtonElement>('[data-project-filter] .filter-pill').forEach((btn) => {

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -26,6 +26,10 @@ const projects = defineCollection({
         })
         .default({}),
       featured: z.boolean().default(false),
+      // Published on a real storefront (Play / App Store / Steam …). Drives
+      // the "Published" filter pill on /projects so visitors can narrow
+      // straight to the shipped catalog.
+      published: z.boolean().default(false),
       // Cover image — used as hero on detail page + thumbnail on cards.
       coverImage: image().optional(),
       // Optional gallery — additional screenshots shown on detail page.

--- a/src/content/projects/brick-game-tr.md
+++ b/src/content/projects/brick-game-tr.md
@@ -20,6 +20,7 @@ gallery:
   - "../../assets/projects/brick-game/gallery/05-colors-tr.png"
 youtubeId: "8HeRix3L7K0"
 featured: true
+published: true
 order: 2
 lang: tr
 ---

--- a/src/content/projects/brick-game.md
+++ b/src/content/projects/brick-game.md
@@ -20,6 +20,7 @@ gallery:
   - "../../assets/projects/brick-game/gallery/05-colors.png"
 youtubeId: "8HeRix3L7K0"
 featured: true
+published: true
 order: 2
 ---
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -43,7 +43,7 @@ type Dict = {
     links: string;
     screenshots: string;
   };
-  projectFilter: { all: string; aria: string };
+  projectFilter: { all: string; published: string; aria: string };
   projectCard: { view: string };
   blogCard: { read: string };
   notFound: { errorTag: string; gameOver: string; body: string; restart: string };
@@ -100,7 +100,7 @@ const en: Dict = {
     links: 'Links',
     screenshots: 'Screenshots',
   },
-  projectFilter: { all: 'All', aria: 'Filter projects by platform' },
+  projectFilter: { all: 'All', published: 'Published', aria: 'Filter projects' },
   projectCard: { view: 'View →' },
   blogCard: { read: 'Read →' },
   notFound: {
@@ -176,7 +176,7 @@ const tr: Dict = {
     links: 'Bağlantılar',
     screenshots: 'Ekran Görüntüleri',
   },
-  projectFilter: { all: 'Tümü', aria: 'Projeleri platforma göre filtrele' },
+  projectFilter: { all: 'Tümü', published: 'Yayında', aria: 'Projeleri filtrele' },
   projectCard: { view: 'Aç →' },
   blogCard: { read: 'Oku →' },
   notFound: {

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -17,6 +17,7 @@ const projects = (
 const PLATFORM_ORDER = ['Mobile', 'PC', 'VR', 'Web'] as const;
 const present = new Set(projects.map((p) => p.data.platform));
 const platforms = PLATFORM_ORDER.filter((p) => present.has(p));
+const hasPublished = projects.some((p) => p.data.published);
 ---
 
 <BaseLayout
@@ -32,12 +33,15 @@ const platforms = PLATFORM_ORDER.filter((p) => present.has(p));
       </p>
     </header>
 
-    <ProjectFilter platforms={platforms} lang={lang} />
+    <ProjectFilter platforms={platforms} showPublished={hasPublished} lang={lang} />
 
     <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
       {
         projects.map((project) => (
-          <div data-project-platform={project.data.platform}>
+          <div
+            data-project-platform={project.data.platform}
+            data-project-published={project.data.published ? 'true' : undefined}
+          >
             <ProjectCard project={project} lang={lang} />
           </div>
         ))

--- a/src/pages/tr/projects/index.astro
+++ b/src/pages/tr/projects/index.astro
@@ -15,6 +15,7 @@ const projects = (
 const PLATFORM_ORDER = ['Mobile', 'PC', 'VR', 'Web'] as const;
 const present = new Set(projects.map((p) => p.data.platform));
 const platforms = PLATFORM_ORDER.filter((p) => present.has(p));
+const hasPublished = projects.some((p) => p.data.published);
 ---
 
 <BaseLayout
@@ -30,12 +31,15 @@ const platforms = PLATFORM_ORDER.filter((p) => present.has(p));
       </p>
     </header>
 
-    <ProjectFilter platforms={platforms} lang={lang} />
+    <ProjectFilter platforms={platforms} showPublished={hasPublished} lang={lang} />
 
     <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
       {
         projects.map((project) => (
-          <div data-project-platform={project.data.platform}>
+          <div
+            data-project-platform={project.data.platform}
+            data-project-published={project.data.published ? 'true' : undefined}
+          >
             <ProjectCard project={project} lang={lang} />
           </div>
         ))


### PR DESCRIPTION
Adds a second filter dimension to /projects so visitors can narrow straight to shipped games. The pill shows after platforms (All → Mobile → PC → VR → Published) and only when at least one project has `published: true`. Brick Game gets the flag now.

- Schema: `published: boolean` (default false)
- ProjectFilter: new `showPublished` prop + new `data-variant="status"` styling
- Client JS routes the `published` pill to `data-project-published` instead of platform
- i18n: `Published` / `Yayında`
- URL param stays `?platform=...` for backward compat (`?platform=published` now valid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)