### PR TITLE
content(blog): tighter intro that leads straight into the video

### DIFF
--- a/src/content/blog/april-2026-developer-update-tr.mdx
+++ b/src/content/blog/april-2026-developer-update-tr.mdx
@@ -8,7 +8,7 @@ lang: tr
 ---
 import LiteYouTube from '@components/LiteYouTube.astro';
 
-Nisan ayında neler yaptığımın hızlı bir özeti — yazmaktansa göstermek daha kolay geldi.
+Nisan ayında neler yaptığımın hızlı bir özeti. Bütün detaylar videoda:
 
 <LiteYouTube id="sePnGxZ2Sdg" title="Nisan 2026 Geliştirici Güncellemesi" />
 

--- a/src/content/blog/april-2026-developer-update.mdx
+++ b/src/content/blog/april-2026-developer-update.mdx
@@ -7,7 +7,7 @@ heroImage: ../../assets/blog/april-2026.png
 ---
 import LiteYouTube from '@components/LiteYouTube.astro';
 
-Quick rundown of what April looked like — easier to show than write up.
+Quick rundown of what April looked like. Full breakdown in the video:
 
 <LiteYouTube id="sePnGxZ2Sdg" title="April 2026 Developer Update" />
 

--- a/src/content/blog/may-2026-developer-update-tr.mdx
+++ b/src/content/blog/may-2026-developer-update-tr.mdx
@@ -8,7 +8,7 @@ lang: tr
 ---
 import LiteYouTube from '@components/LiteYouTube.astro';
 
-Mayıs ayında elimde üç oyun vardı — **Brick Game**, **Mini Fantasy Defence** ve **Draw Rush**. Yazmaktansa göstermek daha kolay geldi.
+Mayıs ayında elimde üç oyun vardı — **Brick Game**, **Mini Fantasy Defence** ve **Draw Rush**. Bütün detaylar videoda:
 
 <LiteYouTube id="iseK-Mc4m_4" title="Mayıs 2026 Geliştirici Güncellemesi" />
 

--- a/src/content/blog/may-2026-developer-update.mdx
+++ b/src/content/blog/may-2026-developer-update.mdx
@@ -7,7 +7,7 @@ heroImage: ../../assets/blog/may-2026.jpg
 ---
 import LiteYouTube from '@components/LiteYouTube.astro';
 
-Three games on the workbench in May — **Brick Game**, **Mini Fantasy Defence**, and **Draw Rush**. Easier to show than write up.
+Three games on the workbench in May — **Brick Game**, **Mini Fantasy Defence**, and **Draw Rush**. Full breakdown in the video:
 
 <LiteYouTube id="iseK-Mc4m_4" title="May 2026 Developer Update" />
 


### PR DESCRIPTION
Replace 'easier to show than write up' / 'yazmaktansa göstermek daha kolay geldi' with a colon-led handoff: 'Full breakdown in the video:' / 'Bütün detaylar videoda:'. Applied to both April and May 2026 dev updates so the devlog series shares a consistent intro shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)