### PR TITLE
content(blog): plainer intro copy across devlog posts

### DIFF
--- a/src/content/blog/april-2026-developer-update-tr.mdx
+++ b/src/content/blog/april-2026-developer-update-tr.mdx
@@ -8,7 +8,7 @@ lang: tr
 ---
 import LiteYouTube from '@components/LiteYouTube.astro';
 
-Nisan ayında neler yaptığımın hızlı bir özeti. Bütün detaylar videoda:
+İşte Nisan ayında yaptıklarım. Bütün detaylar videoda:
 
 <LiteYouTube id="sePnGxZ2Sdg" title="Nisan 2026 Geliştirici Güncellemesi" />
 

--- a/src/content/blog/april-2026-developer-update.mdx
+++ b/src/content/blog/april-2026-developer-update.mdx
@@ -7,7 +7,7 @@ heroImage: ../../assets/blog/april-2026.png
 ---
 import LiteYouTube from '@components/LiteYouTube.astro';
 
-Quick rundown of what April looked like. Full breakdown in the video:
+Here's what I worked on in April. Full breakdown in the video:
 
 <LiteYouTube id="sePnGxZ2Sdg" title="April 2026 Developer Update" />
 

--- a/src/content/blog/may-2026-developer-update-tr.mdx
+++ b/src/content/blog/may-2026-developer-update-tr.mdx
@@ -8,7 +8,7 @@ lang: tr
 ---
 import LiteYouTube from '@components/LiteYouTube.astro';
 
-Mayıs ayında elimde üç oyun vardı — **Brick Game**, **Mini Fantasy Defence** ve **Draw Rush**. Bütün detaylar videoda:
+Mayıs ayında üç oyun üzerinde çalıştım: **Brick Game**, **Mini Fantasy Defence** ve **Draw Rush**. Bütün detaylar videoda:
 
 <LiteYouTube id="iseK-Mc4m_4" title="Mayıs 2026 Geliştirici Güncellemesi" />
 

--- a/src/content/blog/may-2026-developer-update.mdx
+++ b/src/content/blog/may-2026-developer-update.mdx
@@ -7,7 +7,7 @@ heroImage: ../../assets/blog/may-2026.jpg
 ---
 import LiteYouTube from '@components/LiteYouTube.astro';
 
-Three games on the workbench in May — **Brick Game**, **Mini Fantasy Defence**, and **Draw Rush**. Full breakdown in the video:
+Three games I worked on in May: **Brick Game**, **Mini Fantasy Defence**, and **Draw Rush**. Full breakdown in the video:
 
 <LiteYouTube id="iseK-Mc4m_4" title="May 2026 Developer Update" />
 


### PR DESCRIPTION
Drop the ornate phrasings ('on the workbench', 'elimde üç oyun vardı') for direct sentences that read the way you'd describe the month out loud. Same colon → video handoff.

- May EN: 'Three games I worked on in May:'
- May TR: 'Mayıs ayında üç oyun üzerinde çalıştım:'
- April EN: 'Here's what I worked on in April.'
- April TR: 'İşte Nisan ayında yaptıklarım.'

🤖 Generated with [Claude Code](https://claude.com/claude-code)